### PR TITLE
[SECURITY] Enforce strong auth validation

### DIFF
--- a/server/__tests__/auth.test.ts
+++ b/server/__tests__/auth.test.ts
@@ -12,7 +12,7 @@ describe('auth flow', () => {
     const agent = request.agent(app);
     await agent
       .post('/api/register')
-      .send({ username: 'alice', email: 'a@a.com', password: 'secret', confirmPassword: 'secret' })
+      .send({ username: 'alice', email: 'a@a.com', password: 'Secret1!', confirmPassword: 'Secret1!' })
       .expect(200);
     await agent.get('/api/protected').expect(200);
     await agent.post('/api/logout').expect(200);
@@ -23,11 +23,11 @@ describe('auth flow', () => {
     const agent = request.agent(app);
     await agent
       .post('/api/register')
-      .send({ username: 'bob', email: 'b@b.com', password: 'secret', confirmPassword: 'secret' })
+      .send({ username: 'bob', email: 'b@b.com', password: 'Secret1!', confirmPassword: 'Secret1!' })
       .expect(200);
     await agent
       .post('/api/login')
-      .send({ email: 'b@b.com', password: 'wrong12' })
+      .send({ email: 'b@b.com', password: 'Wrong123!' })
       .expect(401);
   });
 });

--- a/src/lib/__tests__/validators.test.ts
+++ b/src/lib/__tests__/validators.test.ts
@@ -3,12 +3,17 @@ import { loginSchema, registerSchema } from '../validators';
 
 describe('loginSchema', () => {
   it('validates correct data', () => {
-    const result = loginSchema.safeParse({ email: 'test@example.com', password: 'abcdef' });
+    const result = loginSchema.safeParse({ email: 'test@example.com', password: 'Abcdef1!' });
     expect(result.success).toBe(true);
   });
 
   it('fails on invalid email', () => {
-    const result = loginSchema.safeParse({ email: 'bad', password: 'abcdef' });
+    const result = loginSchema.safeParse({ email: 'bad', password: 'Abcdef1!' });
+    expect(result.success).toBe(false);
+  });
+
+  it('fails on weak password', () => {
+    const result = loginSchema.safeParse({ email: 'test@example.com', password: 'abcdef' });
     expect(result.success).toBe(false);
   });
 });
@@ -16,20 +21,40 @@ describe('loginSchema', () => {
 describe('registerSchema', () => {
   it('validates correct data', () => {
     const result = registerSchema.safeParse({
-      username: 'user',
+      username: 'valid_user',
       email: 'a@b.com',
-      password: 'abcdef',
-      confirmPassword: 'abcdef',
+      password: 'Abcdef1!',
+      confirmPassword: 'Abcdef1!',
     });
     expect(result.success).toBe(true);
   });
 
   it('fails when passwords do not match', () => {
     const result = registerSchema.safeParse({
-      username: 'user',
+      username: 'valid_user',
+      email: 'a@b.com',
+      password: 'Abcdef1!',
+      confirmPassword: 'Abcdef2!',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('fails on invalid username', () => {
+    const result = registerSchema.safeParse({
+      username: 'bad user!',
+      email: 'a@b.com',
+      password: 'Abcdef1!',
+      confirmPassword: 'Abcdef1!',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('fails on weak password', () => {
+    const result = registerSchema.safeParse({
+      username: 'valid_user',
       email: 'a@b.com',
       password: 'abcdef',
-      confirmPassword: 'abc',
+      confirmPassword: 'abcdef',
     });
     expect(result.success).toBe(false);
   });

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,16 +1,44 @@
 import { z } from 'zod';
 
+const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+const USERNAME_REGEX = /^[a-zA-Z0-9_-]{3,20}$/;
+
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(6),
+  password: z
+    .string()
+    .min(8)
+    .regex(
+      PASSWORD_REGEX,
+      'Password must contain letters, numbers and symbols',
+    ),
 });
 
 export const registerSchema = z
   .object({
-    username: z.string().min(3),
+    username: z
+      .string()
+      .min(3)
+      .max(20)
+      .regex(
+        USERNAME_REGEX,
+        'Username can only contain letters, numbers, underscores and hyphens',
+      ),
     email: z.string().email(),
-    password: z.string().min(6),
-    confirmPassword: z.string().min(6),
+    password: z
+      .string()
+      .min(8)
+      .regex(
+        PASSWORD_REGEX,
+        'Password must contain letters, numbers and symbols',
+      ),
+    confirmPassword: z
+      .string()
+      .min(8)
+      .regex(
+        PASSWORD_REGEX,
+        'Password must contain letters, numbers and symbols',
+      ),
   })
   .refine(data => data.password === data.confirmPassword, {
     message: 'Passwords do not match',


### PR DESCRIPTION
## Summary
- strengthen password requirements and username rules
- update unit tests for new validation
- adjust server auth tests for strong passwords

## Security Impact
- **Audit Finding:** SEC-2025-001
- **Before:** passwords only needed 6 characters and usernames had no restrictions.
- **After:** passwords require at least 8 characters with letters, numbers and symbols, and usernames are limited to 3-20 allowed characters.
- This mitigates weak credential creation and reduces attack surface.

## Verification Steps
1. `pnpm install`
2. `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f6e64d6c83228ff30b71d6161d57