### PR TITLE
[SECURITY] Centralize fetch helper with retry

### DIFF
--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -1,5 +1,10 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { logError } from '@/lib/errors';
+import { apiFetch } from '@/lib/api';
+import articlesFallback from '../../public/data/articles.json';
+import marketFallback from '../../public/data/market-data.json';
+import categoriesFallback from '../../public/data/categories.json';
+import trendingFallback from '../../public/data/trending-topics.json';
 
 interface Article {
   id: string;
@@ -112,22 +117,11 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setError(null);
     
     try {
-      const [articlesResponse, marketResponse, categoriesResponse, trendingResponse] = await Promise.all([
-        fetch('/data/articles.json'),
-        fetch('/data/market-data.json'),
-        fetch('/data/categories.json'),
-        fetch('/data/trending-topics.json'),
-      ]);
-
-      if (!articlesResponse.ok || !marketResponse.ok || !categoriesResponse.ok || !trendingResponse.ok) {
-        throw new Error('Failed to load data');
-      }
-
       const [articlesData, marketDataResponse, categoriesData, trendingData] = await Promise.all([
-        articlesResponse.json(),
-        marketResponse.json(),
-        categoriesResponse.json(),
-        trendingResponse.json(),
+        apiFetch<Article[]>('/data/articles.json'),
+        apiFetch<MarketData>('/data/market-data.json'),
+        apiFetch<Category[]>('/data/categories.json'),
+        apiFetch<TrendingTopic[]>('/data/trending-topics.json'),
       ]);
 
       setArticles(articlesData);
@@ -137,6 +131,10 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({ children
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
       logError(err, 'loadInitialData');
+      setArticles(articlesFallback as Article[]);
+      setMarketData(marketFallback as MarketData);
+      setCategories(categoriesFallback as Category[]);
+      setTrendingTopics(trendingFallback as TrendingTopic[]);
     } finally {
       setIsLoading(false);
     }

--- a/src/lib/__tests__/api.test.ts
+++ b/src/lib/__tests__/api.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { apiFetch } from '../api';
+import { NetworkError } from '../errors';
+
+vi.stubGlobal('fetch', vi.fn());
+
+describe('apiFetch', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns json on success', async () => {
+    (fetch as unknown as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ok: 1 }),
+    });
+    const data = await apiFetch<{ ok: number }>('/good');
+    expect(data.ok).toBe(1);
+  });
+
+  it('retries on failure', async () => {
+    (fetch as unknown as vi.Mock)
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({ retry: true }) });
+    const data = await apiFetch<{ retry: boolean }>('/retry', {}, { retries: 1, timeout: 100 });
+    expect((fetch as vi.Mock).mock.calls.length).toBe(2);
+    expect(data.retry).toBe(true);
+  });
+
+  it('throws after retries', async () => {
+    (fetch as unknown as vi.Mock).mockRejectedValue(new Error('fail'));
+    await expect(apiFetch('/err', {}, { retries: 1, timeout: 10 })).rejects.toBeInstanceOf(NetworkError);
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,31 @@
+export interface FetchOptions {
+  retries?: number;
+  timeout?: number;
+}
+
+import { NetworkError } from './errors';
+
+export const apiFetch = async <T>(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+  options: FetchOptions = {},
+): Promise<T> => {
+  const { retries = 1, timeout = 5000 } = options;
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const response = await fetch(input, { ...init, signal: controller.signal });
+    clearTimeout(id);
+    if (!response.ok) {
+      throw new NetworkError(`HTTP ${response.status}`, response.status);
+    }
+    return (await response.json()) as T;
+  } catch (error) {
+    clearTimeout(id);
+    if (retries > 0) {
+      return apiFetch<T>(input, init, { retries: retries - 1, timeout });
+    }
+    throw new NetworkError((error as Error).message);
+  }
+};


### PR DESCRIPTION
## Summary
- add generic `apiFetch` helper with timeout and retry
- refactor token and data contexts to use new helper
- provide fallback data when requests fail
- test new helper

## Security Impact
- Addresses audit finding **SEC-2025-001** by ensuring API calls use consistent timeout and retry logic
- Reduces risk of unhandled network errors and improves resilience

### Before
- `fetch` calls lacked retries and timeout handling
- failed requests left components without data

### After
- all API calls route through `apiFetch` with retry/timeout
- on failure, components load safe fallback data

## Verification Steps
1. `npm test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6857fb42f1788322af3655bda61c1b76