### PR TITLE
[SECURITY] Increase auth test coverage

### DIFF
--- a/src/lib/__tests__/authToken.extra.test.ts
+++ b/src/lib/__tests__/authToken.extra.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.stubGlobal('fetch', vi.fn());
+
+// Need dynamic import to apply env vars before module initialization
+
+const loadModule = async () => {
+  vi.resetModules();
+  return await import('../authToken');
+};
+
+describe('authToken failure scenarios', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns null when getToken fails', async () => {
+    (fetch as unknown as vi.Mock).mockRejectedValueOnce(new Error('net'));
+    const { getToken } = await loadModule();
+    const token = await getToken();
+    expect(token).toBeNull();
+  });
+
+  it('wraps errors in TokenError for apiRequest', async () => {
+    (fetch as unknown as vi.Mock).mockRejectedValueOnce(new Error('boom'));
+    const { apiRequest } = await loadModule();
+    await expect(apiRequest('/fail')).rejects.toHaveProperty('name', 'TokenError');
+  });
+
+  it('passes cookie options from env', async () => {
+    process.env.COOKIE_DOMAIN = 'example.com';
+    process.env.COOKIE_MAX_AGE = '1000';
+    process.env.NODE_ENV = 'production';
+    vi.resetModules();
+    const { setToken } = await import('../authToken');
+    (fetch as unknown as vi.Mock).mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(null) });
+    await setToken({ user: { id: '99' } });
+    const body = JSON.parse((fetch as vi.Mock).mock.calls[0][1].body as string);
+    expect(body.cookie.domain).toBe('example.com');
+    expect(body.cookie.maxAge).toBe(1000);
+    expect(body.cookie.secure).toBe(true);
+    expect(body.cookie.httpOnly).toBe(true);
+  });
+});

--- a/src/lib/__tests__/validators.test.ts
+++ b/src/lib/__tests__/validators.test.ts
@@ -59,3 +59,18 @@ describe('registerSchema', () => {
     expect(result.success).toBe(false);
   });
 });
+
+it('fails when email missing', () => {
+  const result = loginSchema.safeParse({ password: 'Abcdef1!' });
+  expect(result.success).toBe(false);
+});
+
+it('fails on short username', () => {
+  const result = registerSchema.safeParse({
+    username: 'a',
+    email: 'a@b.com',
+    password: 'Abcdef1!',
+    confirmPassword: 'Abcdef1!',
+  });
+  expect(result.success).toBe(false);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,9 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     environmentMatchGlobs: [['server/**', 'node']],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add failure and cookie handling tests for authToken
- cover missing fields in validation schemas
- enable v8 coverage reporting

## Security Impact
- ensures authentication failures and cookie options are correctly handled
- improves test coverage to expose potential input validation issues

Audit finding: SEC-2025-001

## Verification Steps
- `pnpm install`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6857fca287cc832293d8990d595570d6