### PR TITLE
[SECURITY] Enforce HTTPS redirect and document requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ The application works out of the box with mock data. For production, configure:
 - Authentication backend
 - Database for user management
 - CDN for image assets
+- HTTPS termination at your proxy or load balancer. The app enforces HTTPS in
+  production and will redirect insecure requests.
 
 ## 📈 Future Enhancements
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,6 +28,20 @@ export const resetUsers = (): void => {
 };
 
 export const app = express();
+app.enable('trust proxy');
+
+/**
+ * Redirect HTTP traffic to HTTPS when in production.
+ */
+export const enforceHttps: express.RequestHandler = (req, res, next) => {
+  const host = req.headers.host;
+  if (isProd && !req.secure && host) {
+    return res.redirect(301, `https://${host}${req.originalUrl}`);
+  }
+  next();
+};
+
+app.use(enforceHttps);
 app.use(express.json());
 const isProd = process.env.NODE_ENV === 'production';
 const cookieName = isProd ? '__Secure-sid' : 'sid';


### PR DESCRIPTION
## Summary
- enforce HTTPS in server by redirecting HTTP requests
- document HTTPS termination requirement in README

## Security Impact
- **Finding**: SEC-2025-001 noted missing HTTPS enforcement
- **Before**: Server accepted HTTP requests in production
- **After**: Server now redirects to HTTPS when `NODE_ENV=production`

## Verification Steps
- `pnpm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857fdba3c548322b913e0e4b3fa1e19