### PR TITLE
[SECURITY] Sanitize HTML rendering via DOMPurify

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cmdk": "1.0.0",
     "csurf": "^1.11.0",
     "date-fns": "^3.0.0",
+    "dompurify": "^3.2.6",
     "dotenv": "^16.5.0",
     "embla-carousel-react": "^8.5.2",
     "express": "^4.19.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       date-fns:
         specifier: ^3.0.0
         version: 3.6.0
+      dompurify:
+        specifier: ^3.2.6
+        version: 3.2.6
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -1709,6 +1712,9 @@ packages:
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@typescript-eslint/eslint-plugin@8.29.1':
     resolution: {integrity: sha512-ba0rr4Wfvg23vERs3eB+P3lfj2E+2g3lhWcCVukUuhtcdUx5lSIFZlGFEBHKr+3zizDa/TvZTptdNHVZWAkSBg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2202,6 +2208,9 @@ packages:
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  dompurify@3.2.6:
+    resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
 
   dotenv@16.5.0:
     resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
@@ -5076,6 +5085,9 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.6.3))(eslint@9.24.0(jiti@1.21.7))(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -5583,6 +5595,10 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.0
       csstype: 3.1.3
+
+  dompurify@3.2.6:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@16.5.0: {}
 

--- a/src/components/pages/ArticlePage.tsx
+++ b/src/components/pages/ArticlePage.tsx
@@ -33,6 +33,7 @@ import { useData } from '@/contexts/DataContext';
 import { useAuth } from '@/contexts/AuthContext';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import ArticleCard from '@/components/ui/ArticleCard';
+import { sanitizeHtml } from '@/lib/sanitizeHtml';
 
 interface Comment {
   id: string;
@@ -339,9 +340,13 @@ const ArticlePage: React.FC = () => {
           {/* Article Content */}
           <div className="article-content mb-12">
             {article.content.split('\n\n').map((paragraph, index) => (
-              <p key={index} className="mb-6 leading-relaxed">
-                {paragraph}
-              </p>
+              <p
+                key={index}
+                className="mb-6 leading-relaxed"
+                dangerouslySetInnerHTML={{
+                  __html: sanitizeHtml(paragraph),
+                }}
+              />
             ))}
           </div>
 
@@ -434,9 +439,12 @@ const ArticlePage: React.FC = () => {
                           {formatCommentDate(comment.timestamp)}
                         </span>
                       </div>
-                      <p className="text-muted-foreground mb-3 leading-relaxed">
-                        {comment.content}
-                      </p>
+                      <p
+                        className="text-muted-foreground mb-3 leading-relaxed"
+                        dangerouslySetInnerHTML={{
+                          __html: sanitizeHtml(comment.content),
+                        }}
+                      />
                       <div className="flex items-center space-x-4">
                         <Button variant="ghost" size="sm" className="h-8 px-2">
                           <ThumbsUp className="h-3 w-3 mr-1" />

--- a/src/lib/__tests__/sanitizeHtml.test.ts
+++ b/src/lib/__tests__/sanitizeHtml.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeHtml } from '../sanitizeHtml';
+
+// vitest runs in jsdom environment allowing DOMPurify to function
+
+describe('sanitizeHtml', () => {
+  it('removes script tags', () => {
+    const dirty = '<img src=x onerror=alert(1)><script>alert(2)</script>';
+    const clean = sanitizeHtml(dirty);
+    expect(clean).not.toMatch(/<script/);
+    expect(clean).not.toMatch(/onerror/);
+  });
+
+  it('preserves safe markup', () => {
+    const dirty = '<b>bold</b><i>italic</i>';
+    const clean = sanitizeHtml(dirty);
+    expect(clean).toBe('<b>bold</b><i>italic</i>');
+  });
+});

--- a/src/lib/sanitizeHtml.ts
+++ b/src/lib/sanitizeHtml.ts
@@ -1,0 +1,11 @@
+import DOMPurify from 'dompurify';
+
+/**
+ * Sanitize HTML to prevent XSS attacks before rendering.
+ *
+ * @param dirty - Untrusted HTML string supplied by users.
+ * @returns Sanitized HTML safe for rendering with `dangerouslySetInnerHTML`.
+ */
+export const sanitizeHtml = (dirty: string): string => {
+  return DOMPurify.sanitize(dirty, { USE_PROFILES: { html: true } });
+};


### PR DESCRIPTION
## Summary
- add DOMPurify dependency
- create `sanitizeHtml` util to clean HTML
- sanitize article body and comment display
- test sanitizer utility

## Security Impact
Addresses audit finding **SEC-2025-001** about potential XSS vulnerabilities. Sanitizing all rendered HTML mitigates client-side script injection risks.

## Verification Steps
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685800d317188322903e96ddef56f97c