### PR TITLE
[SECURITY] Fix profile prototype pollution

### DIFF
--- a/server/__tests__/profile.test.ts
+++ b/server/__tests__/profile.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+import request from 'supertest';
+process.env.SESSION_SECRET = 'test-secret';
+process.env.RATE_LIMIT_MAX = '10';
+process.env.RATE_LIMIT_WINDOW_MS = '1000';
+const { app, resetUsers, resetNonces, _authLimiter } = await import('../index.ts');
+
+describe('profile update', () => {
+  beforeEach(() => {
+    resetUsers();
+    resetNonces();
+    _authLimiter.resetKey('::ffff:127.0.0.1');
+    _authLimiter.resetKey('127.0.0.1');
+  });
+
+  it('updates whitelisted fields only', async () => {
+    const agent = request.agent(app);
+    await agent
+      .post('/api/register')
+      .send({ username: 'carol', email: 'c@c.com', password: 'Secret1!', confirmPassword: 'Secret1!' })
+      .expect(200);
+    await agent.post('/api/profile').send({ username: 'newcarol' }).expect(200);
+    const token = await agent.get('/api/token').expect(200);
+    expect(token.body.user.username).toBe('newcarol');
+  });
+
+  it('prevents id change and prototype pollution', async () => {
+    const agent = request.agent(app);
+    await agent
+      .post('/api/register')
+      .send({ username: 'dave', email: 'd@d.com', password: 'Secret1!', confirmPassword: 'Secret1!' })
+      .expect(200);
+    const initial = await agent.get('/api/token').expect(200);
+    const originalId = initial.body.user.id;
+    await agent
+      .post('/api/profile')
+      .send({ id: 'hacked', '__proto__': { isAdmin: true }, username: 'dave2' })
+      .expect(200);
+    const after = await agent.get('/api/token').expect(200);
+    expect(after.body.user.id).toBe(originalId);
+    expect((after.body.user as any).isAdmin).toBeUndefined();
+    expect(after.body.user.username).toBe('dave2');
+  });
+  it('sanitizes malicious input', async () => {
+    const agent = request.agent(app);
+    await agent
+      .post('/api/register')
+      .send({ username: 'eve', email: 'e@e.com', password: 'Secret1!', confirmPassword: 'Secret1!' })
+      .expect(200);
+    await agent
+      .post('/api/profile')
+      .send({ username: '<script>alert(1)</script>evy' })
+      .expect(200);
+    const after = await agent.get('/api/token').expect(200);
+    expect(after.body.user.username).not.toMatch(/<script>/);
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -241,8 +241,28 @@ app.get('/api/protected', requireAuth, (req, res) => {
   res.json({ success: true });
 });
 
+/**
+ * Sanitize untrusted string input to prevent injection attacks.
+ * Simple replacement of angle brackets is used to neutralize HTML.
+ *
+ * @param input - Raw user provided value
+ * @returns Sanitized string safe for storage
+ */
+const sanitizeInput = (input: unknown): string => {
+  if (typeof input !== 'string') return '';
+  return input.replace(/[<>]/g, '').trim();
+};
+
+const allowedProfileFields = ['username', 'email', 'bio', 'avatar', 'displayName'] as const;
+
 app.post('/api/profile', requireAuth, (req, res) => {
-  Object.assign(req.session.user, req.body);
+  const profileUpdates: Record<string, string> = {};
+  allowedProfileFields.forEach(field => {
+    if (req.body[field] !== undefined) {
+      profileUpdates[field] = sanitizeInput(req.body[field]);
+    }
+  });
+  Object.assign(req.session.user, profileUpdates);
   res.json({ success: true });
 });
 


### PR DESCRIPTION
## Summary
- whitelist fields for profile updates
- sanitize profile inputs
- add tests preventing prototype pollution

## Security Impact
- **Fixes SEC-2025-001**: prevents privilege escalation via profile updates
- session properties can no longer be overwritten
- new tests cover malicious payloads and ensure session integrity

## Verification Steps
- `npm test`
- `npm run test:security`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_68580bc42a6c83229c0c3c7839636f16