### PR TITLE
[SECURITY] Persist user data in PostgreSQL

### DIFF
--- a/server/__tests__/auth.test.ts
+++ b/server/__tests__/auth.test.ts
@@ -3,11 +3,12 @@ import request from 'supertest';
 process.env.SESSION_SECRET = 'test-secret';
 process.env.RATE_LIMIT_MAX = '10';
 process.env.RATE_LIMIT_WINDOW_MS = '1000';
+process.env.DATABASE_URL = 'postgresql://appuser:testpass@localhost/appdb';
 const { app, resetUsers, resetNonces, resetLoginAttempts, _nonceStore, _authLimiter } = await import('../index.ts');
 
 describe('auth flow', () => {
-  beforeEach(() => {
-    resetUsers();
+  beforeEach(async () => {
+    await resetUsers();
     resetNonces();
     resetLoginAttempts();
     _authLimiter.resetKey('::ffff:127.0.0.1');

--- a/server/__tests__/profile.test.ts
+++ b/server/__tests__/profile.test.ts
@@ -3,11 +3,12 @@ import request from 'supertest';
 process.env.SESSION_SECRET = 'test-secret';
 process.env.RATE_LIMIT_MAX = '10';
 process.env.RATE_LIMIT_WINDOW_MS = '1000';
+process.env.DATABASE_URL = 'postgresql://appuser:testpass@localhost/appdb';
 const { app, resetUsers, resetNonces, _authLimiter } = await import('../index.ts');
 
 describe('profile update', () => {
-  beforeEach(() => {
-    resetUsers();
+  beforeEach(async () => {
+    await resetUsers();
     resetNonces();
     _authLimiter.resetKey('::ffff:127.0.0.1');
     _authLimiter.resetKey('127.0.0.1');

--- a/server/__tests__/securityHeaders.test.ts
+++ b/server/__tests__/securityHeaders.test.ts
@@ -4,11 +4,12 @@ import request from 'supertest';
 process.env.SESSION_SECRET = 'test-secret';
 process.env.RATE_LIMIT_MAX = '10';
 process.env.RATE_LIMIT_WINDOW_MS = '1000';
+process.env.DATABASE_URL = 'postgresql://appuser:testpass@localhost/appdb';
 const { app, resetUsers, resetNonces, _authLimiter } = await import('../index.ts');
 
 describe('security headers', () => {
-  beforeEach(() => {
-    resetUsers();
+  beforeEach(async () => {
+    await resetUsers();
     resetNonces();
     _authLimiter.resetKey('::ffff:127.0.0.1');
     _authLimiter.resetKey('127.0.0.1');

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,0 +1,86 @@
+import { Pool } from 'pg';
+
+export class DatabaseError extends Error {
+  constructor(message: string, public cause?: unknown) {
+    super(message);
+    this.name = 'DatabaseError';
+  }
+}
+
+const connStr = process.env.DATABASE_URL;
+if (!connStr) {
+  throw new DatabaseError('DATABASE_URL is required');
+}
+
+export const pool = new Pool({ connectionString: connStr, idleTimeoutMillis: 30000, max: 10 });
+
+export async function initDb(): Promise<void> {
+  try {
+    await pool.query(`CREATE TABLE IF NOT EXISTS users (
+      id UUID PRIMARY KEY,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      wallet_address TEXT UNIQUE,
+      username TEXT,
+      bio TEXT,
+      avatar TEXT,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )`);
+  } catch (err) {
+    throw new DatabaseError('Failed to initialize database', err);
+  }
+}
+
+export async function backupDatabase(path: string): Promise<void> {
+  const { exec } = await import('node:child_process');
+  return new Promise((resolve, reject) => {
+    exec(`pg_dump ${connStr} > ${path}`, err => {
+      if (err) reject(new DatabaseError('Backup failed', err));
+      else resolve();
+    });
+  });
+}
+
+export async function restoreDatabase(path: string): Promise<void> {
+  const { exec } = await import('node:child_process');
+  return new Promise((resolve, reject) => {
+    exec(`psql ${connStr} < ${path}`, err => {
+      if (err) reject(new DatabaseError('Restore failed', err));
+      else resolve();
+    });
+  });
+}
+
+export async function createUser(data: {id: string; email: string; passwordHash: string; username: string; walletAddress?: string;}): Promise<void> {
+  try {
+    await pool.query(
+      'INSERT INTO users (id, email, password_hash, username, wallet_address) VALUES ($1,$2,$3,$4,$5)',
+      [data.id, data.email, data.passwordHash, data.username, data.walletAddress || null]
+    );
+  } catch (err) {
+    throw new DatabaseError('Failed to create user', err);
+  }
+}
+
+export async function findUserByEmail(email: string): Promise<any | null> {
+  try {
+    const res = await pool.query('SELECT * FROM users WHERE email=$1', [email]);
+    return res.rows[0] || null;
+  } catch (err) {
+    throw new DatabaseError('Failed to fetch user', err);
+  }
+}
+
+export async function clearUsers(): Promise<void> {
+  await pool.query('DELETE FROM users');
+}
+
+export async function findUserByWallet(address: string): Promise<any | null> {
+  try {
+    const res = await pool.query('SELECT * FROM users WHERE wallet_address=$1', [address]);
+    return res.rows[0] || null;
+  } catch (err) {
+    throw new DatabaseError('Failed to fetch wallet user', err);
+  }
+}


### PR DESCRIPTION
## Summary
- move user records to a PostgreSQL table
- add database utility helpers with backup & restore
- update auth logic to query the database
- adapt tests for async DB cleanup

## Security Impact
- Addresses audit finding **SEC-2025-006** by replacing volatile in-memory storage with persistent PostgreSQL
- Adds connection pooling and error handling for all DB operations

## Verification Steps
- `npm test`
- `npm run test:security`


------
https://chatgpt.com/codex/tasks/task_e_685812e24b0c8322ad9f2cc5e417a535