### PR TITLE
[SECURITY] Add comprehensive security tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "input-otp": "^1.4.2",
         "lucide-react": "^0.364.0",
         "next-themes": "^0.4.4",
+        "pg": "^8.16.2",
         "react": "^18.3.1",
         "react-day-picker": "8.10.1",
         "react-dom": "^18.3.1",
@@ -7776,6 +7777,95 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.16.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.2.tgz",
+      "integrity": "sha512-OtLWF0mKLmpxelOt9BqVq83QV6bTfsS0XLegIeAKqKjurRnRKie1Dc1iL89MugmSLhftxw6NNCyZhm1yQFLMEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.2",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.6"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.6.tgz",
+      "integrity": "sha512-uxmJAnmIgmYgnSFzgOf2cqGQBzwnRYcrEgXuFjJNEkpedEIPBSEzxY7ph4uA9k1mI+l/GR0HjPNS6FKNZe8SBQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.2.tgz",
+      "integrity": "sha512-Ci7jy8PbaWxfsck2dwZdERcDG2A0MG8JoQILs+uZNjABFuBuItAZCWUNz8sXRDMoui24rJw7WlXqgpMdBSN/vQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7954,6 +8044,45 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -8813,6 +8942,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -10186,6 +10324,15 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^0.364.0",
     "next-themes": "^0.4.4",
+    "pg": "^8.16.2",
     "react": "^18.3.1",
     "react-day-picker": "8.10.1",
     "react-dom": "^18.3.1",

--- a/server/__tests__/performanceSecurity.test.ts
+++ b/server/__tests__/performanceSecurity.test.ts
@@ -1,0 +1,29 @@
+// Rate limiting performance security tests
+import { describe, it, beforeEach, expect } from 'vitest';
+import request from 'supertest';
+process.env.SESSION_SECRET = 'a-very-long-and-secure-session-secret-key';
+process.env.RATE_LIMIT_MAX = '10';
+process.env.RATE_LIMIT_WINDOW = '1000';
+process.env.DATABASE_URL = 'postgresql://appuser:testpass@localhost/appdb';
+const { app, resetUsers, resetNonces, resetLoginAttempts, _authLimiter } = await import('../index.ts');
+
+describe('Performance Security', () => {
+  beforeEach(async () => {
+    await resetUsers();
+    resetNonces();
+    resetLoginAttempts();
+    _authLimiter.resetKey('::ffff:127.0.0.1');
+    _authLimiter.resetKey('127.0.0.1');
+  });
+
+  it('handles rate limiting correctly', async () => {
+    const requests = Array.from({ length: 50 }, () =>
+      request(app)
+        .post('/api/login')
+        .send({ email: 'test@example.com', password: 'wrong' })
+    );
+    const responses = await Promise.all(requests);
+    const rateLimited = responses.filter(r => r.status === 429);
+    expect(rateLimited.length).toBeGreaterThan(0);
+  });
+});

--- a/server/__tests__/securityAdditional.test.ts
+++ b/server/__tests__/securityAdditional.test.ts
@@ -1,0 +1,95 @@
+// Security tests for authentication, session management, headers, and input validation
+import { describe, it, beforeEach, expect } from 'vitest';
+import request from 'supertest';
+process.env.SESSION_SECRET = 'a-very-long-and-secure-session-secret-key';
+process.env.RATE_LIMIT_MAX = '10';
+process.env.RATE_LIMIT_WINDOW = '1000';
+process.env.DATABASE_URL = 'postgresql://appuser:testpass@localhost/appdb';
+const { app, resetUsers, resetNonces, resetLoginAttempts, _authLimiter } = await import('../index.ts');
+
+describe('Security Tests', () => {
+  beforeEach(async () => {
+    await resetUsers();
+    resetNonces();
+    resetLoginAttempts();
+    _authLimiter.resetKey('::ffff:127.0.0.1');
+    _authLimiter.resetKey('127.0.0.1');
+  });
+
+  describe('Authentication Security', () => {
+    it('rejects wallet login without signature', async () => {
+      const res = await request(app)
+        .post('/api/login/wallet')
+        .send({ walletAddress: '0x742d35Cc6634C0532925a3b8D2B7D17a33b6C4d0' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('signature');
+    });
+
+    it('performs constant-time login attempts', async () => {
+      const agent = request.agent(app);
+      await agent
+        .post('/api/register')
+        .send({ username: 'tim', email: 'tim@test.com', password: 'Secret1!', confirmPassword: 'Secret1!' })
+        .expect(200);
+      const start1 = Date.now();
+      await agent
+        .post('/api/login')
+        .send({ email: 'tim@test.com', password: 'wrong' });
+      const time1 = Date.now() - start1;
+      const start2 = Date.now();
+      await agent
+        .post('/api/login')
+        .send({ email: 'bad@test.com', password: 'password123' });
+      const time2 = Date.now() - start2;
+      expect(Math.abs(time1 - time2)).toBeLessThan(50);
+    });
+  });
+
+  describe('Session Security', () => {
+    it('prevents session property manipulation', async () => {
+      const agent = request.agent(app);
+      await agent
+        .post('/api/register')
+        .send({ username: 'sally', email: 'sally@test.com', password: 'Secret1!', confirmPassword: 'Secret1!' })
+        .expect(200);
+      await agent
+        .post('/api/profile')
+        .send({ username: 'newname', id: 'malicious', isAdmin: true, __proto__: { evil: true } })
+        .expect(200);
+      const profile = await agent.get('/api/token').expect(200);
+      expect(profile.body.user.username).toBe('newname');
+      expect(profile.body.user.id).not.toBe('malicious');
+      expect((profile.body.user as any).isAdmin).toBeUndefined();
+    });
+  });
+
+  describe('Security Headers', () => {
+    it('includes required security headers', async () => {
+      const res = await request(app).get('/');
+      expect(res.headers['x-frame-options']).toBe('DENY');
+      expect(res.headers['x-content-type-options']).toBe('nosniff');
+      expect(res.headers['x-xss-protection']).toBe('1; mode=block');
+      expect(res.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+      expect(res.headers['content-security-policy']).toContain("default-src 'self'");
+    });
+  });
+
+  describe('Input Validation', () => {
+    it('rejects invalid wallet addresses', async () => {
+      const invalid = [
+        'not-an-address',
+        '0xinvalid',
+        '0x742d35Cc6634C0532925a3b8D2B7D17a33b6C4d',
+        '0x742d35Cc6634C0532925a3b8D2B7D17a33b6C4d00',
+        '',
+        null,
+      ];
+      for (const addr of invalid) {
+        const res = await request(app)
+          .post('/api/login/wallet')
+          .send({ walletAddress: addr });
+        expect(res.status).toBe(400);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add security regression tests covering auth, session, headers, and input validation
- add rate limit performance security tests
- include pg dependency for test environment

## Security Impact
- **Audit Finding**: addresses regression gap (SEC-2025-001)
- Adds automated tests to catch authentication and session manipulation issues
- Verifies security headers and input sanitization remain enforced

Before: security coverage limited to basic scenarios.
After: suite verifies login timing, invalid wallet cases, session property protection, and rate limiting.

## Verification Steps
- `npm run test:security`
- `npm test`
- `npm audit` (no high/critical vulnerabilities)

Both test commands fail in this environment due to missing Postgres service.

------
https://chatgpt.com/codex/tasks/task_e_6858195b28d08322829e5527e9b3746b