### PR TITLE
[BUGFIX] reset db between tests

### DIFF
--- a/server/__tests__/auth.test.ts
+++ b/server/__tests__/auth.test.ts
@@ -4,7 +4,15 @@ process.env.SESSION_SECRET = 'a-very-long-and-secure-session-secret-key';
 process.env.RATE_LIMIT_MAX = '10';
 process.env.RATE_LIMIT_WINDOW = '1000';
 process.env.DATABASE_URL = 'postgresql://appuser:testpass@localhost/appdb';
-const { app, resetUsers, resetNonces, resetLoginAttempts, _nonceStore, _authLimiter } = await import('../index.ts');
+const {
+  app,
+  resetUsers,
+  resetNonces,
+  resetLoginAttempts,
+  _nonceStore,
+  _authLimiter,
+  shutdown,
+} = await import('../index.ts');
 
 describe('auth flow', () => {
   beforeEach(async () => {
@@ -13,6 +21,10 @@ describe('auth flow', () => {
     resetLoginAttempts();
     _authLimiter.resetKey('::ffff:127.0.0.1');
     _authLimiter.resetKey('127.0.0.1');
+  });
+
+  afterAll(async () => {
+    await shutdown();
   });
 
   it('registers, accesses protected route, and logs out', async () => {

--- a/server/__tests__/profile.test.ts
+++ b/server/__tests__/profile.test.ts
@@ -4,7 +4,13 @@ process.env.SESSION_SECRET = 'a-very-long-and-secure-session-secret-key';
 process.env.RATE_LIMIT_MAX = '10';
 process.env.RATE_LIMIT_WINDOW = '1000';
 process.env.DATABASE_URL = 'postgresql://appuser:testpass@localhost/appdb';
-const { app, resetUsers, resetNonces, _authLimiter } = await import('../index.ts');
+const {
+  app,
+  resetUsers,
+  resetNonces,
+  _authLimiter,
+  shutdown,
+} = await import('../index.ts');
 
 describe('profile update', () => {
   beforeEach(async () => {
@@ -12,6 +18,10 @@ describe('profile update', () => {
     resetNonces();
     _authLimiter.resetKey('::ffff:127.0.0.1');
     _authLimiter.resetKey('127.0.0.1');
+  });
+
+  afterAll(async () => {
+    await shutdown();
   });
 
   it('updates whitelisted fields only', async () => {

--- a/server/__tests__/securityHeaders.test.ts
+++ b/server/__tests__/securityHeaders.test.ts
@@ -5,7 +5,13 @@ process.env.SESSION_SECRET = 'a-very-long-and-secure-session-secret-key';
 process.env.RATE_LIMIT_MAX = '10';
 process.env.RATE_LIMIT_WINDOW = '1000';
 process.env.DATABASE_URL = 'postgresql://appuser:testpass@localhost/appdb';
-const { app, resetUsers, resetNonces, _authLimiter } = await import('../index.ts');
+const {
+  app,
+  resetUsers,
+  resetNonces,
+  _authLimiter,
+  shutdown,
+} = await import('../index.ts');
 
 describe('security headers', () => {
   beforeEach(async () => {
@@ -13,6 +19,10 @@ describe('security headers', () => {
     resetNonces();
     _authLimiter.resetKey('::ffff:127.0.0.1');
     _authLimiter.resetKey('127.0.0.1');
+  });
+
+  afterAll(async () => {
+    await shutdown();
   });
 
   it('sets comprehensive security headers', async () => {

--- a/server/db.ts
+++ b/server/db.ts
@@ -32,6 +32,19 @@ export async function initDb(): Promise<void> {
   }
 }
 
+export async function resetDatabase(): Promise<void> {
+  try {
+    await pool.query('DROP TABLE IF EXISTS users CASCADE');
+    await initDb();
+  } catch (err) {
+    throw new DatabaseError('Failed to reset database', err);
+  }
+}
+
+export async function closePool(): Promise<void> {
+  await pool.end();
+}
+
 export async function backupDatabase(path: string): Promise<void> {
   const { exec } = await import('node:child_process');
   return new Promise((resolve, reject) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,7 +14,8 @@ import {
   createUser,
   findUserByEmail,
   findUserByWallet,
-  clearUsers,
+  resetDatabase,
+  closePool,
 } from './db';
 
 dotenv.config();
@@ -60,7 +61,7 @@ interface User {
 }
 
 export const resetUsers = async (): Promise<void> => {
-  await clearUsers();
+  await resetDatabase();
 };
 
 interface NonceEntry {
@@ -82,6 +83,10 @@ const loginAttempts = new Map<string, AttemptInfo>();
 export const _loginAttempts = loginAttempts; // test-only export
 export const resetLoginAttempts = (): void => {
   loginAttempts.clear();
+};
+
+export const shutdown = async (): Promise<void> => {
+  await closePool();
 };
 
 export const app = express();


### PR DESCRIPTION
## Security Impact Assessment
- Authentication: none
- Data Protection: ensures clean database state for tests
- Attack Prevention: reduces risk of state bleed across tests

## Changes Made
- Added `resetDatabase` and `closePool` helpers in `server/db.ts`
- Updated `resetUsers` to drop and recreate tables
- Exported `shutdown` for test teardown
- Included teardown logic in auth, profile, and security headers tests

## Verification Steps
- [ ] Security tests pass (`pnpm run test:security`)
- [ ] Manual authentication testing
- [ ] Browser security header validation
- [ ] Performance impact assessment

## Additional Notes
- Database connection still required for tests to run

------
https://chatgpt.com/codex/tasks/task_e_6858304e578483228800d4eaf471990e