### PR TITLE
[SECURITY] validate wallet signature before address

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -286,7 +286,12 @@ app.post('/api/login/wallet/nonce', authLimiter, validateWalletAddress, (req, re
 
 app.post('/api/login/wallet', authLimiter, validateWalletAddress, async (req, res) => {
   try {
-    const { walletAddress, signature } = walletLoginSchema.parse(req.body);
+    const { walletAddress } = req.body as { walletAddress: string };
+    const { signature } = req.body as { signature?: string };
+    if (!signature) {
+      return res.status(400).json({ error: 'signature required' });
+    }
+    walletLoginSchema.pick({ signature: true }).parse({ signature });
     const entry = nonceStore.get(walletAddress.toLowerCase());
     if (!entry || entry.expiresAt < Date.now()) {
       return res.status(400).json({ error: 'Nonce expired' });


### PR DESCRIPTION
## Security Impact Assessment
- Authentication: improved wallet login validation by requiring signatures before signature verification
- Data Protection: no change
- Attack Prevention: addresses missing signature handling to prevent info leakage

## Changes Made
- Added explicit check for `signature` in `/api/login/wallet`
- Applied zod schema for signature field only

## Verification Steps
- [ ] Security tests pass *(failed: database not available)*
- [ ] Manual authentication testing *(not run)*
- [ ] Browser security header validation *(not run)*
- [ ] Performance impact assessment *(not run)*

## Additional Notes
- TypeScript build failed due to missing bcryptjs type definitions
- Audit shows 4 low/moderate vulnerabilities


------
https://chatgpt.com/codex/tasks/task_e_6858338f33308322af92bb8fe6d8f45d