### PR TITLE
Add secure auth utilities and tests

### DIFF
--- a/src/lib/__tests__/AuthContext.test.tsx
+++ b/src/lib/__tests__/AuthContext.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { AuthProvider, useAuth } from '../auth/AuthContext';
+
+vi.mock('../api', () => ({ apiFetch: vi.fn().mockResolvedValue({}) }));
+vi.mock('../auth/Web3AuthManager', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      connectWallet: vi.fn().mockResolvedValue({
+        address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        signer: {},
+      }),
+      signAuthMessage: vi.fn().mockResolvedValue('0x'.padEnd(132, 'a')),
+    })),
+  };
+});
+
+describe('AuthContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loginWithToken sets session', () => {
+    const token = 'eyJhbGciOiJIUzI1NiJ9.' +
+      btoa(JSON.stringify({ sub: '1', exp: Math.floor(Date.now() / 1000) + 60 }));
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    act(() => result.current.loginWithToken(token));
+    expect(result.current.session?.userId).toBe('1');
+  });
+
+  it('loginWithWallet sets session address', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    await act(async () => {
+      await result.current.loginWithWallet('nonce');
+    });
+    expect(result.current.session?.address).toMatch(/^0x/);
+  });
+});

--- a/src/lib/__tests__/AuthValidator.test.ts
+++ b/src/lib/__tests__/AuthValidator.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeNonce, sanitizeAddress, sanitizeMessage } from '../auth/AuthValidator';
+
+describe('AuthValidator', () => {
+  it('sanitizes nonce', () => {
+    expect(sanitizeNonce('abc123!@#')).toBe('abc123');
+  });
+
+  it('sanitizes address', () => {
+    const addr = ' 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 ';
+    expect(sanitizeAddress(addr)).toBe('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045');
+    expect(sanitizeAddress('bad')).toBe('');
+    expect(sanitizeAddress('0x742d35Cc6634C0532925a3b8D2B7D17a33b6C4d0')).toBe('');
+  });
+
+  it('sanitizes message html', () => {
+    const dirty = '<script>evil()</script>hello';
+    expect(sanitizeMessage(dirty)).toBe('hello');
+  });
+});

--- a/src/lib/__tests__/SecureTokenManager.test.ts
+++ b/src/lib/__tests__/SecureTokenManager.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import SecureTokenManager from '../auth/SecureTokenManager';
+
+const createToken = (exp: number): string => {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+    .toString('base64')
+    .replace(/=/g, '');
+  const payload = Buffer.from(JSON.stringify({ exp })).toString('base64')
+    .replace(/=/g, '');
+  return `${header}.${payload}.signature`;
+};
+
+describe('SecureTokenManager', () => {
+  beforeEach(() => {
+    const manager = SecureTokenManager.getInstance();
+    manager.clearTokens();
+    vi.useRealTimers();
+  });
+
+  it('returns stored token if valid', () => {
+    const token = createToken(Math.floor(Date.now() / 1000) + 60);
+    const manager = SecureTokenManager.getInstance();
+    manager.setTokens(token);
+    expect(manager.getToken()).toBe(token);
+  });
+
+  it('returns null for expired token', () => {
+    const token = createToken(Math.floor(Date.now() / 1000) - 60);
+    const manager = SecureTokenManager.getInstance();
+    manager.setTokens(token);
+    expect(manager.getToken()).toBeNull();
+  });
+
+  it('clears token after cleanup interval', () => {
+    vi.useFakeTimers();
+    const token = createToken(Math.floor(Date.now() / 1000) + 60);
+    const manager = SecureTokenManager.getInstance();
+    manager.setTokens(token);
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
+    expect(manager.getToken()).toBeNull();
+    vi.useRealTimers();
+  });
+});

--- a/src/lib/__tests__/Web3AuthManager.test.ts
+++ b/src/lib/__tests__/Web3AuthManager.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Web3AuthManager from '../auth/Web3AuthManager';
+
+class MockProvider {
+  send = vi.fn();
+  getSigner = vi.fn().mockResolvedValue({
+    getAddress: vi.fn().mockResolvedValue('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'),
+    signMessage: vi.fn().mockResolvedValue('0x'.padEnd(132, 'a')),
+  });
+}
+
+declare global {
+  interface Window { ethereum?: unknown; }
+}
+
+describe('Web3AuthManager', () => {
+  beforeEach(() => {
+    window.ethereum = { request: vi.fn() } as any;
+  });
+
+  it('connects wallet and returns address', async () => {
+    const mgr = new Web3AuthManager(() => new MockProvider() as any);
+    const result = await mgr.connectWallet();
+    expect(result.address).toBe('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045');
+  });
+
+  it('signs authentication message', async () => {
+    const mgr = new Web3AuthManager(() => new MockProvider() as any);
+    const sig = await mgr.signAuthMessage('nonce', '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045');
+    expect(sig).toMatch(/^0x/);
+  });
+});

--- a/src/lib/auth/AuthContext.tsx
+++ b/src/lib/auth/AuthContext.tsx
@@ -1,0 +1,79 @@
+import React, { createContext, useContext, useState } from 'react';
+import { apiFetch } from '../api';
+import SecureTokenManager from './SecureTokenManager';
+import Web3AuthManager from './Web3AuthManager';
+import { sanitizeNonce } from './AuthValidator';
+
+interface Session {
+  userId?: string;
+  address?: string;
+}
+
+interface AuthValue {
+  session: Session | null;
+  loading: boolean;
+  loginWithToken: (token: string) => void;
+  loginWithWallet: (nonce: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthValue | null>(null);
+
+const parseJwt = (token: string): any => {
+  const payload = token.split('.')[1];
+  const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+  const json = decodeURIComponent(
+    atob(base64)
+      .split('')
+      .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+      .join(''),
+  );
+  return JSON.parse(json);
+};
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const tokenManager = SecureTokenManager.getInstance();
+  const web3 = new Web3AuthManager();
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const loginWithToken = (token: string): void => {
+    tokenManager.setTokens(token);
+    const payload = parseJwt(token) as { sub?: string };
+    setSession({ userId: payload?.sub });
+  };
+
+  const loginWithWallet = async (nonce: string): Promise<void> => {
+    setLoading(true);
+    try {
+      const cleanNonce = sanitizeNonce(nonce);
+      const { address } = await web3.connectWallet();
+      const signature = await web3.signAuthMessage(cleanNonce, address);
+      await apiFetch(`${process.env.API_BASE || ''}/api/web3-login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ address, signature, nonce: cleanNonce }),
+      });
+      setSession({ address });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const logout = (): void => {
+    tokenManager.clearTokens();
+    setSession(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ session, loading, loginWithToken, loginWithWallet, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = (): AuthValue => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('AuthProvider missing');
+  return ctx;
+};

--- a/src/lib/auth/AuthValidator.ts
+++ b/src/lib/auth/AuthValidator.ts
@@ -1,0 +1,15 @@
+import { isValidEthereumAddress } from '../validators';
+import { sanitizeHtml } from '../sanitizeHtml';
+
+export const sanitizeNonce = (nonce: string): string => {
+  return nonce.replace(/[^a-zA-Z0-9]/g, '').slice(0, 64);
+};
+
+export const sanitizeAddress = (address: string): string => {
+  const trimmed = address.trim();
+  return isValidEthereumAddress(trimmed) ? trimmed : '';
+};
+
+export const sanitizeMessage = (message: string): string => {
+  return sanitizeHtml(message).slice(0, 2000);
+};

--- a/src/lib/auth/SecureTokenManager.ts
+++ b/src/lib/auth/SecureTokenManager.ts
@@ -1,0 +1,66 @@
+export interface JwtPayload {
+  exp: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Singleton for secure token management with in-memory storage.
+ */
+export class SecureTokenManager {
+  private static instance: SecureTokenManager;
+  private token: string | null = null;
+  private refreshToken: string | null = null;
+
+  private constructor() {}
+
+  static getInstance(): SecureTokenManager {
+    if (!SecureTokenManager.instance) {
+      SecureTokenManager.instance = new SecureTokenManager();
+    }
+    return SecureTokenManager.instance;
+  }
+
+  setTokens(accessToken: string, refreshToken?: string): void {
+    this.token = accessToken;
+    this.refreshToken = refreshToken || null;
+    this.scheduleTokenCleanup();
+  }
+
+  getToken(): string | null {
+    if (!this.token) return null;
+    try {
+      const payload = this.parseJWT(this.token);
+      if (payload.exp * 1000 < Date.now()) {
+        this.clearTokens();
+        return null;
+      }
+      return this.token;
+    } catch {
+      this.clearTokens();
+      return null;
+    }
+  }
+
+  clearTokens(): void {
+    this.token = null;
+    this.refreshToken = null;
+  }
+
+  private parseJWT(token: string): JwtPayload {
+    const base64Url = token.split('.')[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join(''),
+    );
+    return JSON.parse(jsonPayload) as JwtPayload;
+  }
+
+  private scheduleTokenCleanup(): void {
+    setTimeout(() => this.clearTokens(), 24 * 60 * 60 * 1000);
+  }
+}
+
+export default SecureTokenManager;

--- a/src/lib/auth/Web3AuthManager.ts
+++ b/src/lib/auth/Web3AuthManager.ts
@@ -1,0 +1,47 @@
+import { ethers } from 'ethers';
+import { isValidEthereumAddress } from '../validators';
+
+/**
+ * Web3 authentication helper for wallet connection and message signing.
+ */
+export class Web3AuthManager {
+  constructor(private providerFactory: () => ethers.BrowserProvider = () => new ethers.BrowserProvider((window as any).ethereum)) {}
+
+  async connectWallet(): Promise<{ address: string; signer: ethers.Signer }> {
+    if (!(window as any).ethereum) {
+      throw new Error('Web3 wallet not detected');
+    }
+    try {
+      const provider = this.providerFactory();
+      await provider.send('eth_requestAccounts', []);
+      const signer = await provider.getSigner();
+      const address = await signer.getAddress();
+      if (!isValidEthereumAddress(address)) {
+        throw new Error('Invalid wallet address format');
+      }
+      return { address, signer };
+    } catch (error: any) {
+      throw new Error(`Wallet connection failed: ${error.message}`);
+    }
+  }
+
+  async signAuthMessage(nonce: string, address: string): Promise<string> {
+    if (!(window as any).ethereum) {
+      throw new Error('Web3 wallet not available');
+    }
+    const provider = this.providerFactory();
+    const signer = await provider.getSigner();
+    const message = `BlockchainNews Authentication\nNonce: ${nonce}\nAddress: ${address}\nTimestamp: ${Date.now()}`;
+    try {
+      const signature = await signer.signMessage(message);
+      if (!/^0x[a-fA-F0-9]{130}$/.test(signature)) {
+        throw new Error('Invalid signature format');
+      }
+      return signature;
+    } catch (error: any) {
+      throw new Error(`Message signing failed: ${error.message}`);
+    }
+  }
+}
+
+export default Web3AuthManager;

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,6 +1,17 @@
 import { z } from 'zod';
 import { getAddress } from 'ethers';
 
+export const isValidEthereumAddress = (address: string): boolean => {
+  if (!address || typeof address !== 'string') return false;
+  if (!/^0x[a-fA-F0-9]{40}$/.test(address)) return false;
+  try {
+    const checksumAddress = getAddress(address);
+    return address === checksumAddress;
+  } catch {
+    return false;
+  }
+};
+
 const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
 const USERNAME_REGEX = /^[a-zA-Z0-9_-]{3,20}$/;
 


### PR DESCRIPTION
## Summary
- implement memory-based SecureTokenManager
- add Web3AuthManager for wallet interactions
- create AuthValidator sanitization helpers
- build AuthContext bridging Web2/Web3 auth
- add comprehensive Vitest coverage for new modules
- expose `isValidEthereumAddress` in validators

## Testing
- `npx vitest run src/lib/__tests__ --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6858aa20a0b0832290b9f76bb492fdba