### PR TITLE
Add CryptoDataStream with reconnect logic

### DIFF
--- a/src/lib/data/CryptoDataStream.ts
+++ b/src/lib/data/CryptoDataStream.ts
@@ -1,0 +1,92 @@
+import { EventEmitter } from 'events';
+
+export class CryptoStreamError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CryptoStreamError';
+  }
+}
+
+export interface StreamOptions {
+  maxRetries?: number;
+}
+
+const DEFAULT_MAX_RETRIES = 5;
+const BASE_URL =
+  (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_WS_BASE_URL) ||
+  process.env.VITE_WS_BASE_URL;
+
+const isValidSymbol = (symbol: string): boolean => /^[A-Za-z0-9]{2,20}$/.test(symbol);
+
+export interface DataEvent {
+  symbol: string;
+  data: unknown;
+}
+
+export type CryptoDataStreamEvents = {
+  open: (symbol: string) => void;
+  message: (payload: DataEvent) => void;
+  close: (symbol: string) => void;
+  error: (err: CryptoStreamError) => void;
+  reconnecting: (symbol: string, attempt: number) => void;
+};
+
+export default class CryptoDataStream extends EventEmitter {
+  private sockets = new Map<string, WebSocket>();
+  private attempts = new Map<string, number>();
+  private maxRetries: number;
+
+  constructor(options: StreamOptions = {}) {
+    super();
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    if (!BASE_URL) {
+      throw new CryptoStreamError('Missing WebSocket base URL');
+    }
+  }
+
+  connect(symbols: string[]): void {
+    symbols.forEach(symbol => this.subscribe(symbol));
+  }
+
+  subscribe(symbol: string): void {
+    if (!isValidSymbol(symbol)) {
+      throw new CryptoStreamError(`Invalid symbol: ${symbol}`);
+    }
+    const url = `${BASE_URL}/${symbol.toLowerCase()}@ticker`;
+    const ws = new WebSocket(url);
+
+    ws.onopen = () => this.emit('open', symbol);
+    ws.onmessage = evt => {
+      try {
+        const data = JSON.parse(evt.data as string);
+        this.emit('message', { symbol, data });
+      } catch (err) {
+        this.emit('error', new CryptoStreamError('Invalid message format'));
+      }
+    };
+    ws.onerror = () => this.emit('error', new CryptoStreamError('WebSocket error'));
+    ws.onclose = () => this.handleClose(symbol);
+
+    this.sockets.set(symbol, ws);
+    this.attempts.set(symbol, 0);
+  }
+
+  private handleClose(symbol: string): void {
+    const attempt = (this.attempts.get(symbol) ?? 0) + 1;
+    if (attempt > this.maxRetries) {
+      this.emit('error', new CryptoStreamError('Max retries reached'));
+      this.sockets.delete(symbol);
+      return;
+    }
+    this.emit('reconnecting', symbol, attempt);
+    this.attempts.set(symbol, attempt);
+    const delay = 2 ** (attempt - 1) * 1000;
+    setTimeout(() => this.subscribe(symbol), delay);
+  }
+
+  cleanup(): void {
+    this.sockets.forEach(ws => ws.close());
+    this.sockets.clear();
+    this.attempts.clear();
+  }
+}

--- a/src/lib/data/__tests__/CryptoDataStream.test.ts
+++ b/src/lib/data/__tests__/CryptoDataStream.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let CryptoDataStream: any;
+let CryptoStreamError: any;
+
+declare global {
+  interface Window { WebSocket: any }
+}
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  onopen?: () => void;
+  onmessage?: (ev: { data: string }) => void;
+  onclose?: () => void;
+  onerror?: () => void;
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+  }
+  close() {
+    if (this.onclose) this.onclose();
+  }
+  emitMessage(data: unknown) {
+    if (this.onmessage) this.onmessage({ data: JSON.stringify(data) });
+  }
+  triggerError() {
+    if (this.onerror) this.onerror();
+  }
+  open() {
+    if (this.onopen) this.onopen();
+  }
+}
+
+vi.stubGlobal('WebSocket', MockWebSocket);
+
+beforeEach(async () => {
+  process.env.VITE_WS_BASE_URL = 'wss://example.com/ws';
+  const mod = await import('../CryptoDataStream');
+  CryptoDataStream = mod.default;
+  CryptoStreamError = mod.CryptoStreamError;
+  MockWebSocket.instances.length = 0;
+  vi.clearAllTimers();
+  vi.useFakeTimers();
+});
+
+describe('CryptoDataStream', () => {
+  it('reconnects with backoff', () => {
+    const stream = new CryptoDataStream();
+    stream.connect(['BTCUSDT']);
+    expect(MockWebSocket.instances.length).toBe(1);
+    MockWebSocket.instances[0].close();
+    vi.advanceTimersByTime(1000);
+    expect(MockWebSocket.instances.length).toBe(2);
+  });
+
+  it('emits error after max retries', () => {
+    const errors: CryptoStreamError[] = [];
+    const stream = new CryptoDataStream({ maxRetries: 2 });
+    stream.on('error', e => errors.push(e));
+    stream.connect(['ETHUSDT']);
+    MockWebSocket.instances[0].close();
+    vi.advanceTimersByTime(1000);
+    MockWebSocket.instances[1].close();
+    vi.advanceTimersByTime(2000);
+    MockWebSocket.instances[2].close();
+    vi.advanceTimersByTime(4000);
+    expect(errors[0]).toBeInstanceOf(CryptoStreamError);
+  });
+
+  it('throws on invalid symbol', () => {
+    const stream = new CryptoDataStream();
+    expect(() => stream.connect(['??'])).toThrow(CryptoStreamError);
+  });
+});
+


### PR DESCRIPTION
## Summary
- implement CryptoDataStream for WebSocket management
- add unit tests covering reconnection and input errors

## Testing
- `pnpm run test:security` *(fails: DatabaseError, Missing WebSocket base URL)*
- `pnpm run type-check` *(fails: Missing script)*
- `pnpm run lint`
- `pnpm audit --audit-level moderate` *(fails: Method forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6858ade554c48322ac472c3683e7b394