### PR TITLE
Implement cache manager with Redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "ioredis": "^5.3.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      ioredis:
+        specifier: ^5.3.2
+        version: 5.6.1
       lucide-react:
         specifier: ^0.364.0
         version: 0.364.0(react@18.3.1)
@@ -637,6 +640,9 @@ packages:
   '@humanwhocodes/retry@0.4.2':
     resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
     engines: {node: '>=18.18'}
+
+  '@ioredis/commands@1.2.0':
+    resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2011,6 +2017,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   cmdk@1.0.0:
     resolution: {integrity: sha512-gDzVf0a09TvoJ5jnuPvygTB77+XdOSwEmJ88L6XPFPlv7T3RxbP9jgenfylrAMD0+Le1aO0nVjQUzl2g+vjz5Q==}
     peerDependencies:
@@ -2198,6 +2208,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -2618,6 +2632,10 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  ioredis@5.6.1:
+    resolution: {integrity: sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==}
+    engines: {node: '>=12.22.0'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -2730,6 +2748,12 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -3225,6 +3249,14 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
@@ -3338,6 +3370,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -4086,6 +4121,8 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.2': {}
+
+  '@ioredis/commands@1.2.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -5238,7 +5275,7 @@ snapshots:
       '@typescript-eslint/types': 8.29.1
       '@typescript-eslint/typescript-estree': 8.29.1(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.29.1
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.24.0(jiti@1.21.7)
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -5550,6 +5587,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   cmdk@1.0.0(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@radix-ui/react-dialog': 1.0.5(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5699,6 +5738,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   depd@1.1.2: {}
 
@@ -6188,6 +6229,20 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  ioredis@5.6.1:
+    dependencies:
+      '@ioredis/commands': 1.2.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.1
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ipaddr.js@1.9.1: {}
 
   is-binary-path@2.1.0:
@@ -6302,6 +6357,10 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -6739,6 +6798,12 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   regenerator-runtime@0.14.1: {}
 
   resolve-from@4.0.0: {}
@@ -6880,6 +6945,8 @@ snapshots:
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   statuses@1.5.0: {}
 

--- a/src/lib/data/CacheManager.ts
+++ b/src/lib/data/CacheManager.ts
@@ -1,0 +1,111 @@
+import Redis from 'ioredis';
+import { logError } from '../errors';
+
+export class CacheError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CacheError';
+  }
+}
+
+interface CacheOptions {
+  ttl?: number;
+  maxEntries?: number;
+  maxMemoryBytes?: number;
+}
+
+interface CacheEntry<T> {
+  value: T;
+  expires: number;
+  size: number;
+}
+
+export default class CacheManager {
+  private memory = new Map<string, CacheEntry<unknown>>();
+  private redis?: Redis;
+  private ttl: number;
+  private maxEntries: number;
+  private maxBytes: number;
+  private currentBytes = 0;
+
+  constructor(options: CacheOptions = {}) {
+    this.ttl = options.ttl ?? 300;
+    this.maxEntries = options.maxEntries ?? 100;
+    this.maxBytes = options.maxMemoryBytes ?? 50 * 1024 * 1024;
+    const url = process.env.REDIS_URL;
+    if (url) {
+      this.redis = new Redis(url);
+    }
+  }
+
+  private setMemory(key: string, value: unknown): void {
+    const data = JSON.stringify(value);
+    const size = Buffer.byteLength(data);
+    const entry = { value, expires: Date.now() + this.ttl * 1000, size };
+    const existing = this.memory.get(key);
+    if (existing) this.currentBytes -= existing.size;
+    this.memory.set(key, entry);
+    this.currentBytes += size;
+    this.enforceLimits();
+  }
+
+  private enforceLimits(): void {
+    while (
+      (this.memory.size > this.maxEntries || this.currentBytes > this.maxBytes) &&
+      this.memory.size
+    ) {
+      const firstKey = this.memory.keys().next().value as string;
+      const entry = this.memory.get(firstKey);
+      if (entry) this.currentBytes -= entry.size;
+      this.memory.delete(firstKey);
+    }
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    const entry = this.memory.get(key);
+    if (entry && entry.expires > Date.now()) {
+      return entry.value as T;
+    }
+    if (entry) {
+      this.currentBytes -= entry.size;
+      this.memory.delete(key);
+    }
+    if (!this.redis) return null;
+    try {
+      const data = await this.redis.get(key);
+      if (!data) return null;
+      const parsed = JSON.parse(data) as T;
+      this.setMemory(key, parsed);
+      return parsed;
+    } catch (err) {
+      logError(err, 'CacheManager:get');
+      throw new CacheError('Redis get failed');
+    }
+  }
+
+  async set<T>(key: string, value: T): Promise<void> {
+    this.setMemory(key, value);
+    if (!this.redis) return;
+    try {
+      await this.redis.set(key, JSON.stringify(value), 'EX', this.ttl);
+    } catch (err) {
+      logError(err, 'CacheManager:set');
+      throw new CacheError('Redis set failed');
+    }
+  }
+
+  async clear(key: string): Promise<void> {
+    const entry = this.memory.get(key);
+    if (entry) {
+      this.currentBytes -= entry.size;
+      this.memory.delete(key);
+    }
+    if (!this.redis) return;
+    try {
+      await this.redis.del(key);
+    } catch (err) {
+      logError(err, 'CacheManager:clear');
+      throw new CacheError('Redis clear failed');
+    }
+  }
+}

--- a/src/lib/data/__tests__/CacheManager.test.ts
+++ b/src/lib/data/__tests__/CacheManager.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+let CacheManager: any;
+let CacheError: any;
+let mockRedis: any;
+
+class MockRedis {
+  store = new Map<string, string>();
+  get = vi.fn(async (key: string) => this.store.get(key) ?? null);
+  set = vi.fn(async (key: string, value: string, mode: string, ttl: number) => {
+    this.store.set(key, value);
+  });
+  del = vi.fn(async (key: string) => {
+    this.store.delete(key);
+  });
+}
+
+beforeEach(async () => {
+  mockRedis = new MockRedis();
+  vi.doMock('ioredis', () => ({ default: vi.fn(() => mockRedis) }));
+  process.env.REDIS_URL = 'redis://localhost:6379';
+  const mod = await import('../CacheManager');
+  CacheManager = mod.default;
+  CacheError = mod.CacheError;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.resetModules();
+  vi.useRealTimers();
+});
+
+describe('CacheManager', () => {
+  it('returns value from memory cache', async () => {
+    const cache = new CacheManager({ ttl: 1 });
+    await cache.set('a', { v: 1 });
+    const val = await cache.get('a');
+    expect(val).toEqual({ v: 1 });
+    expect(mockRedis.set).toHaveBeenCalled();
+    expect(mockRedis.get).not.toHaveBeenCalled();
+  });
+
+  it('falls back to redis on memory miss', async () => {
+    const cache1 = new CacheManager({ ttl: 1 });
+    await cache1.set('b', { v: 2 });
+    const cache2 = new CacheManager({ ttl: 1 });
+    const val = await cache2.get('b');
+    expect(val).toEqual({ v: 2 });
+    expect(mockRedis.get).toHaveBeenCalled();
+  });
+
+  it('throws CacheError on redis failure', async () => {
+    mockRedis.get.mockRejectedValueOnce(new Error('fail'));
+    const cache = new CacheManager();
+    await expect(cache.get('missing')).rejects.toBeInstanceOf(CacheError);
+  });
+});


### PR DESCRIPTION
## Summary
- add a CacheManager library with Redis + in-memory caching
- store items with TTL and enforce memory/size limits
- expose CacheError for Redis problems
- test cache hits, Redis fallback and failure cases
- add `ioredis` runtime dependency

## Testing
- `pnpm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `pnpm vitest run src/lib/data/__tests__/CacheManager.test.ts`
- `pnpm vitest run src/lib` *(fails: CryptoDataStream.test)*
- `pnpm audit --audit-level moderate` *(fails: blocked by network)*

------
https://chatgpt.com/codex/tasks/task_e_6858af588ffc8322830f1517d71652b9