### PR TITLE
Add real-time price and chart hooks

### DIFF
--- a/src/hooks/__tests__/useChartData.test.tsx
+++ b/src/hooks/__tests__/useChartData.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const get = vi.fn();
+const set = vi.fn();
+class MockCache { constructor(){ } get = get; set = set; }
+
+vi.mock('../lib/data/CacheManager', () => ({ default: MockCache }));
+
+import useChartData, { ChartPoint } from '../useChartData';
+
+describe('useChartData', () => {
+  it('uses cache and maintains window', async () => {
+    get.mockResolvedValueOnce(null);
+    const points: ChartPoint[] = [
+      { time: 1, value: 1 },
+      { time: 2, value: 2 },
+      { time: 3, value: 3 },
+    ];
+    const fetcher = vi.fn().mockResolvedValue(points);
+    const { result } = renderHook(() => useChartData('k', fetcher, 3));
+    await waitFor(() => !result.current.loading);
+    expect(fetcher).toHaveBeenCalled();
+    act(() => result.current.addPoint({ time: 4, value: 4 }));
+    expect(result.current.data.length).toBe(3);
+    expect(result.current.data[0].time).toBe(2);
+    expect(set).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useRealTimePrice.test.tsx
+++ b/src/hooks/__tests__/useRealTimePrice.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { EventEmitter } from 'events';
+
+class FakeStream extends EventEmitter {
+  static instances: FakeStream[] = [];
+  connect = vi.fn();
+  cleanup = vi.fn();
+  constructor() {
+    super();
+    FakeStream.instances.push(this);
+  }
+}
+vi.mock('../lib/data/CryptoDataStream', () => ({
+  default: FakeStream,
+  CryptoStreamError: class extends Error {},
+}));
+
+
+describe('useRealTimePrice', () => {
+  beforeEach(() => {
+    FakeStream.instances.length = 0;
+    vi.useFakeTimers();
+  });
+
+  it('throttles price updates', async () => {
+    const { default: useRealTimePrice } = await import('../useRealTimePrice');
+    const { result } = renderHook(() => useRealTimePrice('BTCUSDT'));
+    const stream = FakeStream.instances[0];
+    act(() => {
+      stream.emit('message', { data: { c: 1 } });
+      stream.emit('message', { data: { c: 2 } });
+    });
+    expect(result.current.price).toBe(1);
+    vi.advanceTimersByTime(201);
+    act(() => stream.emit('message', { data: { c: 3 } }));
+    expect(result.current.price).toBe(3);
+  });
+
+  it('cleans up on unmount', async () => {
+    const { default: useRealTimePrice } = await import('../useRealTimePrice');
+    const { unmount } = renderHook(() => useRealTimePrice('ETHUSDT'));
+    const stream = FakeStream.instances[0];
+    unmount();
+    expect(stream.cleanup).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -1,0 +1,38 @@
+import { useCallback, useDeferredValue, useEffect, useState } from 'react';
+import CacheManager from '../lib/data/CacheManager';
+import { logError } from '../lib/errors';
+
+export interface ChartPoint { time: number; value: number; }
+interface ChartState { data: ChartPoint[]; loading: boolean; error: string | null; }
+
+const cache = new CacheManager({ ttl: 60 });
+
+export default function useChartData(
+  key: string,
+  fetcher: () => Promise<ChartPoint[]>,
+  maxPoints = 1000,
+) {
+  const [state, setState] = useState<ChartState>({ data: [], loading: true, error: null });
+  const deferredData = useDeferredValue(state.data);
+
+  const load = useCallback(async () => {
+    setState(s => ({ ...s, loading: true, error: null }));
+    try {
+      const cached = await cache.get<ChartPoint[]>(key);
+      const points = cached ?? await fetcher();
+      if (!cached) await cache.set(key, points);
+      setState({ data: points.slice(-maxPoints), loading: false, error: null });
+    } catch (err) {
+      setState({ data: [], loading: false, error: (err as Error).message });
+      logError(err, 'useChartData');
+    }
+  }, [key, fetcher, maxPoints]);
+
+  const addPoint = useCallback((p: ChartPoint) => {
+    setState(s => ({ ...s, data: [...s.data, p].slice(-maxPoints) }));
+  }, [maxPoints]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return { data: deferredData, loading: state.loading, error: state.error, addPoint };
+}

--- a/src/hooks/useRealTimePrice.ts
+++ b/src/hooks/useRealTimePrice.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { unstable_batchedUpdates } from 'react-dom';
+import CryptoDataStream, { CryptoStreamError, DataEvent } from '../lib/data/CryptoDataStream';
+import { logError } from '../lib/errors';
+
+interface PriceState { price: number | null; loading: boolean; error: string | null; }
+
+const THROTTLE_MS = 200;
+
+export default function useRealTimePrice(symbol: string): PriceState {
+  const [state, setState] = useState<PriceState>({ price: null, loading: true, error: null });
+  const lastRef = useRef(0);
+
+  const handleMessage = useCallback(({ data }: DataEvent) => {
+    const now = Date.now();
+    const price = Number((data as any).c ?? (data as any).price);
+    if (Number.isNaN(price) || now - lastRef.current < THROTTLE_MS) return;
+    lastRef.current = now;
+    unstable_batchedUpdates(() => setState(p => ({ ...p, price, loading: false })));
+  }, []);
+
+  const handleError = useCallback((err: CryptoStreamError) => {
+    unstable_batchedUpdates(() => setState({ price: null, loading: false, error: err.message }));
+    logError(err, 'useRealTimePrice');
+  }, []);
+
+  useEffect(() => {
+    if (!/^[A-Za-z0-9]{2,20}$/.test(symbol)) {
+      setState({ price: null, loading: false, error: 'Invalid symbol' });
+      return;
+    }
+    const stream = new CryptoDataStream();
+    stream.on('message', handleMessage);
+    stream.on('error', handleError);
+    try { stream.connect([symbol]); } catch (err) { handleError(err as CryptoStreamError); }
+    return () => { stream.cleanup(); stream.off('message', handleMessage); stream.off('error', handleError); };
+  }, [symbol, handleMessage, handleError]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary
- implement `useRealTimePrice` hook with throttled batched updates
- add `useChartData` hook that caches data and caps the window
- cover new hooks with tests

## Testing
- `pnpm test src/hooks/__tests__/useRealTimePrice.test.tsx src/hooks/__tests__/useChartData.test.tsx` *(fails: Missing WebSocket base URL)*

------
https://chatgpt.com/codex/tasks/task_e_6858b27c95548322a8018d7ae661ad9b