### PR TITLE
Increase bcrypt cost factor

### DIFF
--- a/server/__tests__/auth.test.ts
+++ b/server/__tests__/auth.test.ts
@@ -190,4 +190,15 @@ describe('auth flow', () => {
     const durationNon = Date.now() - start2;
     expect(Math.abs(durationExisting - durationNon)).toBeLessThan(200);
   });
+
+  it('stores password hashes with cost factor 12', async () => {
+    const agent = request.agent(app);
+    await agent
+      .post('/api/register')
+      .send({ username: 'hash', email: 'hash@test.com', password: 'Secret1!', confirmPassword: 'Secret1!' })
+      .expect(200);
+    const { findUserByEmail } = await import('../db');
+    const user = await findUserByEmail('hash@test.com');
+    expect(user.password_hash).toMatch(/^\$2[abxy]\$12\$/);
+  });
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -271,7 +271,7 @@ app.post('/api/register', authLimiter, async (req, res) => {
     if (exists) {
       return res.status(400).json({ error: 'User exists' });
     }
-    const passwordHash = await bcrypt.hash(password, 10);
+    const passwordHash = await bcrypt.hash(password, 12);
     const user: User = { id: crypto.randomUUID(), username, email, passwordHash };
     await createUser(user);
     req.session.user = sanitize(user);
@@ -292,7 +292,7 @@ app.post('/api/login', authLimiter, async (req, res) => {
     }
     const user = await findUserByEmail(email);
     const hashToCompare =
-      user?.passwordHash || '$2b$10$dummy.hash.for.timing.consistency.protection.only';
+      user?.passwordHash || '$2a$12$4bFcCTq4crRNjgIHpqjWH.a0O5xtQjKhrFrG32JUfwre7O4ngmFOu';
     const isPasswordValid = await bcrypt.compare(password, hashToCompare);
     if (!user || !user.id || !isPasswordValid) {
       if (++attempt.count >= 5) {


### PR DESCRIPTION
## Summary
- tighten server hashing by raising bcrypt cost factor to 12
- update timing constant hash
- test that password hashes use cost factor 12

## Testing
- `pnpm test` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_6858c56fe2ac8322a0b0ebc2adb32936