### PR TITLE
Add sanitization to auth handlers

### DIFF
--- a/src/lib/__tests__/validators.test.ts
+++ b/src/lib/__tests__/validators.test.ts
@@ -4,6 +4,8 @@ import {
   registerSchema,
   ethereumAddressSchema,
   walletLoginSchema,
+  validateInput,
+  validationRules,
 } from '../validators';
 
 describe('loginSchema', () => {
@@ -105,5 +107,18 @@ describe('walletLoginSchema', () => {
   it('requires walletAddress and signature', () => {
     const result = walletLoginSchema.safeParse({ walletAddress: '0x52908400098527886E0F7030069857D2E4169EE7' });
     expect(result.success).toBe(false);
+  });
+});
+
+describe('validateInput', () => {
+  it('rejects XSS payload', () => {
+    const res = validateInput('<script>alert(1)</script>', validationRules.username);
+    expect(res.isValid).toBe(false);
+  });
+
+  it('sanitizes valid input', () => {
+    const res = validateInput('  Alice  ', validationRules.username);
+    expect(res.isValid).toBe(true);
+    expect(res.value).toBe('alice');
   });
 });


### PR DESCRIPTION
## Summary
- implement `validateInput` and expose validation rules in validators
- sanitize and validate input in register/login routes
- test `validateInput` rejects XSS

## Testing
- `pnpm install`
- `npm test` *(fails: DatabaseError & Missing WebSocket base URL)*

------
https://chatgpt.com/codex/tasks/task_e_6858d8757b348322aa72f9002a0d47bf