### PR TITLE
Add dangerous content checks to zod validators

### DIFF
--- a/src/lib/__tests__/validators.test.ts
+++ b/src/lib/__tests__/validators.test.ts
@@ -21,6 +21,11 @@ describe('loginSchema', () => {
     const result = loginSchema.safeParse({ email: 'test@example.com', password: 'abcdef' });
     expect(result.success).toBe(false);
   });
+
+  it('rejects script content', () => {
+    const result = loginSchema.safeParse({ email: '<script>alert(1)</script>', password: 'Abcdef1!' });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('registerSchema', () => {
@@ -63,6 +68,16 @@ describe('registerSchema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('rejects dangerous username', () => {
+    const result = registerSchema.safeParse({
+      username: '<script>alert(1)</script>',
+      email: 'a@b.com',
+      password: 'Abcdef1!',
+      confirmPassword: 'Abcdef1!',
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 it('fails when email missing', () => {
@@ -99,11 +114,25 @@ describe('ethereumAddressSchema', () => {
     );
     expect(result.success).toBe(false);
   });
+
+  it('rejects dangerous content', () => {
+    const result = ethereumAddressSchema.safeParse('javascript:alert(1)');
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('walletLoginSchema', () => {
   it('requires walletAddress and signature', () => {
     const result = walletLoginSchema.safeParse({ walletAddress: '0x52908400098527886E0F7030069857D2E4169EE7' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects dangerous signature', () => {
+    const result = walletLoginSchema.safeParse({
+      walletAddress: '0x52908400098527886E0F7030069857D2E4169EE7',
+      signature: 'javascript:alert(1)',
+      nonce: '123',
+    });
     expect(result.success).toBe(false);
   });
 });

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,6 +1,17 @@
 import { z } from 'zod';
 import { getAddress } from 'ethers';
 
+const dangerousPatterns = [
+  /<script/i,
+  /javascript:/i,
+  /onload=/i,
+  /data:/i,
+];
+
+export const containsDangerousContent = (value: string): boolean => {
+  return dangerousPatterns.some(pattern => pattern.test(value));
+};
+
 export const isValidEthereumAddress = (address: string): boolean => {
   if (!address || typeof address !== 'string') return false;
   if (!/^0x[a-fA-F0-9]{40}$/.test(address)) return false;
@@ -16,14 +27,18 @@ const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
 const USERNAME_REGEX = /^[a-zA-Z0-9_-]{3,20}$/;
 
 export const loginSchema = z.object({
-  email: z.string().email(),
+  email: z
+    .string()
+    .email()
+    .refine(val => !containsDangerousContent(val), 'Invalid content'),
   password: z
     .string()
     .min(8)
     .regex(
       PASSWORD_REGEX,
       'Password must contain letters, numbers and symbols',
-    ),
+    )
+    .refine(val => !containsDangerousContent(val), 'Invalid content'),
 });
 
 export const registerSchema = z
@@ -35,22 +50,28 @@ export const registerSchema = z
       .regex(
         USERNAME_REGEX,
         'Username can only contain letters, numbers, underscores and hyphens',
-      ),
-    email: z.string().email(),
+      )
+      .refine(val => !containsDangerousContent(val), 'Invalid content'),
+    email: z
+      .string()
+      .email()
+      .refine(val => !containsDangerousContent(val), 'Invalid content'),
     password: z
       .string()
       .min(8)
       .regex(
         PASSWORD_REGEX,
         'Password must contain letters, numbers and symbols',
-      ),
+      )
+      .refine(val => !containsDangerousContent(val), 'Invalid content'),
     confirmPassword: z
       .string()
       .min(8)
       .regex(
         PASSWORD_REGEX,
         'Password must contain letters, numbers and symbols',
-      ),
+      )
+      .refine(val => !containsDangerousContent(val), 'Invalid content'),
   })
   .refine(data => data.password === data.confirmPassword, {
     message: 'Passwords do not match',
@@ -67,10 +88,18 @@ export const ethereumAddressSchema = z
     } catch {
       return false;
     }
-  }, 'Invalid address checksum');
+  }, 'Invalid address checksum')
+  .refine(val => !containsDangerousContent(val), 'Invalid content');
 
 export const walletLoginSchema = z.object({
   walletAddress: ethereumAddressSchema,
-  signature: z.string().min(1),
-  nonce: z.string().min(1).optional(),
+  signature: z
+    .string()
+    .min(1)
+    .refine(val => !containsDangerousContent(val), 'Invalid content'),
+  nonce: z
+    .string()
+    .min(1)
+    .refine(val => !containsDangerousContent(val), 'Invalid content')
+    .optional(),
 });


### PR DESCRIPTION
## Summary
- extend validators with helper `containsDangerousContent`
- reject script tags, javascript URLs, onload handlers and data URLs in login and registration data
- sanitize wallet login and ethereum address schemas
- test new sanitization rules for all schemas

## Testing
- `pnpm run test` *(fails: DatabaseError: Failed to initialize database)*

------
https://chatgpt.com/codex/tasks/task_e_6858e62d5b1883229b9211b5c8e25cb1