### PR TITLE
Add DOMPurify-based sanitizer and tests

### DIFF
--- a/server/__tests__/profile.test.ts
+++ b/server/__tests__/profile.test.ts
@@ -60,9 +60,14 @@ describe('profile update', () => {
       .expect(200);
     await agent
       .post('/api/profile')
-      .send({ username: '<script>alert(1)</script>evy' })
+      .send({
+        username: '<img src=x onerror="alert(1)"><script>alert(1)</script>evy',
+        avatar: 'javascript:alert(1)',
+      })
       .expect(200);
     const after = await agent.get('/api/token').expect(200);
     expect(after.body.user.username).not.toMatch(/<script/i);
+    expect(after.body.user.username).not.toMatch(/onerror/i);
+    expect(after.body.user.avatar).not.toMatch(/javascript:/i);
   });
 });

--- a/server/__tests__/sanitize.test.ts
+++ b/server/__tests__/sanitize.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { sanitize } from '../utils/sanitize';
+
+describe('sanitize utility', () => {
+  it('removes script tags', () => {
+    const dirty = '<div>test<script>alert(1)</script></div>';
+    const clean = sanitize(dirty);
+    expect(clean).not.toMatch(/<script/i);
+  });
+
+  it('strips javascript urls', () => {
+    const dirty = '<a href="javascript:alert(1)">x</a>';
+    const clean = sanitize(dirty);
+    expect(clean).not.toMatch(/javascript:/i);
+  });
+
+  it('removes event handlers', () => {
+    const dirty = '<img src="x" onerror="alert(1)">';
+    const clean = sanitize(dirty);
+    expect(clean).not.toMatch(/onerror/i);
+  });
+
+  it('preserves safe markup', () => {
+    const dirty = '<p>Hello <strong>world</strong></p>';
+    const clean = sanitize(dirty);
+    expect(clean).toBe('<p>Hello <strong>world</strong></p>');
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import session from 'express-session';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import csurf from 'csurf';
+import { sanitize } from './utils/sanitize';
 import { ethers } from 'ethers';
 import { validateEnvironment } from './config/environment';
 import { logSecurityEvent } from './logging';
@@ -187,17 +188,6 @@ app.get('/api/protected', requireAuth, (req, res) => {
   res.json({ success: true });
 });
 
-/**
- * Sanitize untrusted string input to prevent injection attacks.
- * Simple replacement of angle brackets is used to neutralize HTML.
- *
- * @param input - Raw user provided value
- * @returns Sanitized string safe for storage
- */
-const sanitizeInput = (input: unknown): string => {
-  if (typeof input !== 'string') return '';
-  return input.replace(/[<>]/g, '').trim();
-};
 
 const allowedProfileFields = ['username', 'email', 'bio', 'avatar', 'displayName'] as const;
 
@@ -205,7 +195,7 @@ app.post('/api/profile', requireAuth, (req, res) => {
   const profileUpdates: Record<string, string> = {};
   allowedProfileFields.forEach(field => {
     if (req.body[field] !== undefined) {
-      profileUpdates[field] = sanitizeInput(req.body[field]);
+      profileUpdates[field] = sanitize(req.body[field]);
     }
   });
   Object.assign(req.session.user, profileUpdates);

--- a/server/utils/sanitize.ts
+++ b/server/utils/sanitize.ts
@@ -1,0 +1,20 @@
+import createDOMPurify from 'dompurify';
+import { JSDOM } from 'jsdom';
+
+const window = new JSDOM('').window as unknown as Window;
+const DOMPurify = createDOMPurify(window);
+
+/**
+ * Sanitize untrusted HTML or text input.
+ * Removes script tags, javascript: URLs and event-handler attributes.
+ *
+ * @param dirty - raw user input
+ * @returns cleaned string safe for storage
+ */
+export const sanitize = (dirty: unknown): string => {
+  if (typeof dirty !== 'string') return '';
+  return DOMPurify.sanitize(dirty, {
+    ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'u', 'p', 'br'],
+    ALLOWED_ATTR: [],
+  });
+};


### PR DESCRIPTION
## Summary
- create `server/utils/sanitize.ts` utility using DOMPurify
- sanitize profile updates via new utility
- add unit test for sanitizer
- extend profile tests for malicious content

## Testing
- `pnpm lint`
- `pnpm test` *(fails: DatabaseError: Failed to initialize database)*

------
https://chatgpt.com/codex/tasks/task_e_6858f0b8c82c83228785688fbf5159bd