### PR TITLE
Add csrf and rate limit tests

### DIFF
--- a/server/__tests__/csrfToken.test.ts
+++ b/server/__tests__/csrfToken.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, beforeEach, afterAll, expect } from 'vitest';
+import request from 'supertest';
+
+process.env.SESSION_SECRET = 'a-very-long-and-secure-session-secret-key';
+process.env.RATE_LIMIT_MAX = '5';
+process.env.RATE_LIMIT_WINDOW = '900000';
+process.env.DATABASE_URL = 'postgresql://appuser:testpass@localhost/appdb';
+process.env.NODE_ENV = 'development';
+
+const { app, resetUsers, resetNonces, _authLimiter, shutdown } = await import('../index.ts');
+
+describe('CSRF token workflow', () => {
+  let agent: request.SuperAgentTest;
+
+  beforeEach(async () => {
+    await resetUsers();
+    resetNonces();
+    _authLimiter.resetKey('::ffff:127.0.0.1');
+    _authLimiter.resetKey('127.0.0.1');
+    agent = request.agent(app);
+  });
+
+  afterAll(async () => {
+    await shutdown();
+  });
+
+  it('accepts requests with valid token and rejects missing or invalid tokens', async () => {
+    const csrfRes = await agent.get('/api/csrf-token').expect(200);
+    const csrfToken = csrfRes.body.csrfToken;
+
+    await agent
+      .post('/api/register')
+      .set('X-CSRF-Token', csrfToken)
+      .send({ username: 'csrf', email: 'c@c.com', password: 'Secret1!', confirmPassword: 'Secret1!' })
+      .expect(200);
+
+    await agent
+      .post('/api/register')
+      .send({ username: 'csrf2', email: 'd@d.com', password: 'Secret1!', confirmPassword: 'Secret1!' })
+      .expect(403);
+
+    await agent
+      .post('/api/register')
+      .set('X-CSRF-Token', 'invalid')
+      .send({ username: 'csrf3', email: 'e@e.com', password: 'Secret1!', confirmPassword: 'Secret1!' })
+      .expect(403);
+  });
+});

--- a/server/__tests__/rateLimiterReset.test.ts
+++ b/server/__tests__/rateLimiterReset.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, beforeEach, afterAll, vi } from 'vitest';
+import request from 'supertest';
+
+process.env.SESSION_SECRET = 'a-very-long-and-secure-session-secret-key';
+process.env.RATE_LIMIT_MAX = '5';
+process.env.RATE_LIMIT_WINDOW = '60000';
+process.env.DATABASE_URL = 'postgresql://appuser:testpass@localhost/appdb';
+process.env.NODE_ENV = 'test';
+
+const { app, resetUsers, resetNonces, _authLimiter, shutdown } = await import('../index.ts');
+
+describe('rate limiter', () => {
+  let agent: request.SuperAgentTest;
+
+  beforeEach(async () => {
+    await resetUsers();
+    resetNonces();
+    _authLimiter.resetKey('::ffff:127.0.0.1');
+    _authLimiter.resetKey('127.0.0.1');
+    vi.useFakeTimers();
+    agent = request.agent(app);
+  });
+
+  afterAll(async () => {
+    vi.useRealTimers();
+    await shutdown();
+  });
+
+  it('blocks after 5 attempts then resets after window', async () => {
+    for (let i = 0; i < 5; i++) {
+      await agent.post('/api/login').send({ email: 'a@a.com', password: 'a' });
+    }
+    await agent.post('/api/login').send({ email: 'a@a.com', password: 'a' }).expect(429);
+    vi.advanceTimersByTime(60000);
+    await agent.post('/api/login').send({ email: 'a@a.com', password: 'a' }).expect(401);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests that use `/api/csrf-token` and verify token handling
- add rate limiter test ensuring reset after window

## Testing
- `pnpm test -- --coverage` *(fails: DatabaseError - permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6859023162588322908e853618b61b61