### PR TITLE
Implement config module with session secret validation

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -1,0 +1,17 @@
+import dotenv from 'dotenv';
+import { validateEnvironment } from './config/environment';
+
+dotenv.config();
+
+const envResult = validateEnvironment();
+if (!envResult.success) {
+  throw new Error(envResult.error);
+}
+
+const envConfig = envResult.data;
+const secret = process.env.SESSION_SECRET;
+if (!secret || secret.length < 32) {
+  throw new Error('SESSION_SECRET must be at least 32 characters of cryptographic randomness');
+}
+
+export const config = { ...envConfig, SESSION_SECRET: secret };

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,11 +1,10 @@
 import express from 'express';
 import session from 'express-session';
 import cors from 'cors';
-import dotenv from 'dotenv';
 import csurf from 'csurf';
 import { sanitize } from './utils/sanitize';
 import { ethers } from 'ethers';
-import { validateEnvironment } from './config/environment';
+import { config } from './config';
 import { logSecurityEvent } from './logging';
 import { authRouter } from './auth';
 import {
@@ -13,15 +12,6 @@ import {
   resetDatabase,
   closePool,
 } from './db';
-
-dotenv.config();
-
-const envResult = validateEnvironment();
-if (!envResult.success) {
-  console.error(envResult.error);
-  process.exit(1);
-}
-const config = envResult.data;
 
 /**
  * Parse and validate cookie settings from environment variables.
@@ -40,9 +30,6 @@ const cookieOptions = parseCookieOptions();
 
 const RATE_LIMIT_WINDOW_MS = config.RATE_LIMIT_WINDOW;
 const RATE_LIMIT_MAX = config.RATE_LIMIT_MAX;
-if (!config.SESSION_SECRET) {
-  throw new Error('SESSION_SECRET is required');
-}
 if (!Number.isFinite(RATE_LIMIT_WINDOW_MS) || !Number.isFinite(RATE_LIMIT_MAX)) {
   throw new Error('Invalid rate limit configuration');
 }


### PR DESCRIPTION
## Summary
- add `server/config.ts` to load env vars and validate `SESSION_SECRET`
- update server to use the new config module

## Testing
- `pnpm test` *(fails: DatabaseError - permission denied)*
- `pnpm test:security` *(fails: DatabaseError - permission denied)*
- `pnpm lint`
- `pnpm audit --audit-level moderate`
- `npx tsc -p tsconfig.server.json` *(errors: missing declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685957e488d883228926a51fef89f153