### PR TITLE
Add session secret generator utility

### DIFF
--- a/server/__tests__/crypto.test.ts
+++ b/server/__tests__/crypto.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { generateSessionSecret } from '../utils/crypto';
+
+describe('generateSessionSecret', () => {
+  it('returns a 64-character hexadecimal string', () => {
+    const secret = generateSessionSecret();
+    expect(secret).toMatch(/^[a-f0-9]{64}$/i);
+  });
+
+  it('generates unique secrets', () => {
+    const first = generateSessionSecret();
+    const second = generateSessionSecret();
+    expect(first).not.toBe(second);
+  });
+});

--- a/server/utils/crypto.ts
+++ b/server/utils/crypto.ts
@@ -1,0 +1,11 @@
+import crypto from 'crypto';
+
+/**
+ * Generate a cryptographically secure session secret.
+ * This should be used when creating production SESSION_SECRET values.
+ *
+ * @returns 64-character hexadecimal secret string
+ */
+export function generateSessionSecret(): string {
+  return crypto.randomBytes(32).toString('hex');
+}


### PR DESCRIPTION
## Summary
- add `generateSessionSecret` helper in server utils
- include unit tests for session secret generation

## Testing
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm test` *(fails: DatabaseError - permission denied)*
- `pnpm test:security` *(fails: DatabaseError - permission denied)*
- `pnpm audit --audit-level moderate`

------
https://chatgpt.com/codex/tasks/task_e_68595de5cb608322ba5e7b72374a04e5