### PR TITLE
Implement EIP-4361 message generation

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -100,11 +100,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     try {
       const cleanNonce = sanitizeNonce(nonce);
       const { address } = await web3.connectWallet();
-      const signature = await web3.signAuthMessage(cleanNonce, address);
+      const { message, signature } = await web3.signAuthMessage(cleanNonce, address);
       const data = await apiRequest<{ token: string; user: User }>('/api/login/wallet', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ address, signature, nonce: cleanNonce }),
+        body: JSON.stringify({ message, signature }),
       });
       setToken(data.token);
       setUser(data.user);

--- a/src/lib/__tests__/Web3AuthManager.test.ts
+++ b/src/lib/__tests__/Web3AuthManager.test.ts
@@ -26,7 +26,11 @@ describe('Web3AuthManager', () => {
 
   it('signs authentication message', async () => {
     const mgr = new Web3AuthManager(() => new MockProvider() as any);
-    const sig = await mgr.signAuthMessage('nonce', '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045');
-    expect(sig).toMatch(/^0x/);
+    const { message, signature } = await mgr.signAuthMessage(
+      'nonce',
+      '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+    );
+    expect(signature).toMatch(/^0x/);
+    expect(message).toContain('Nonce: nonce');
   });
 });

--- a/src/lib/auth/Web3AuthManager.ts
+++ b/src/lib/auth/Web3AuthManager.ts
@@ -1,5 +1,6 @@
 import { ethers } from 'ethers';
 import { isValidEthereumAddress } from '../validators';
+import { generateSignInMessage } from '../web3Utils';
 
 /**
  * Web3 authentication helper for wallet connection and message signing.
@@ -25,19 +26,24 @@ export class Web3AuthManager {
     }
   }
 
-  async signAuthMessage(nonce: string, address: string): Promise<string> {
+  async signAuthMessage(
+    nonce: string,
+    address: string,
+  ): Promise<{ message: string; signature: string }> {
     if (!(window as any).ethereum) {
       throw new Error('Web3 wallet not available');
     }
+
     const provider = this.providerFactory();
     const signer = await provider.getSigner();
-    const message = `BlockchainNews Authentication\nNonce: ${nonce}\nAddress: ${address}\nTimestamp: ${Date.now()}`;
+    const message = generateSignInMessage(address, nonce);
+
     try {
       const signature = await signer.signMessage(message);
       if (!/^0x[a-fA-F0-9]{130}$/.test(signature)) {
         throw new Error('Invalid signature format');
       }
-      return signature;
+      return { message, signature };
     } catch (error: any) {
       throw new Error(`Message signing failed: ${error.message}`);
     }

--- a/src/lib/web3Utils.ts
+++ b/src/lib/web3Utils.ts
@@ -1,0 +1,22 @@
+import { isValidEthereumAddress } from './validators';
+
+/**
+ * Generate an EIP-4361 sign-in message.
+ * @param address Wallet address in checksum format
+ * @param nonce Unique nonce provided by the backend
+ * @returns Formatted message string
+ */
+export function generateSignInMessage(address: string, nonce: string): string {
+  if (!isValidEthereumAddress(address)) {
+    throw new Error('Invalid Ethereum address');
+  }
+  if (!nonce || typeof nonce !== 'string') {
+    throw new Error('Invalid nonce');
+  }
+
+  const domain = window.location.host;
+  const origin = window.location.origin;
+  const timestamp = new Date().toISOString();
+
+  return `${domain} wants you to sign in with your Ethereum account:\n${address}\n\nSign in to BlockchainNews\n\nURI: ${origin}\nVersion: 1\nChain ID: 1\nNonce: ${nonce}\nIssued At: ${timestamp}`;
+}


### PR DESCRIPTION
## Summary
- add `generateSignInMessage` util for EIP‑4361 messages
- return message and signature from `Web3AuthManager.signAuthMessage`
- send `{ message, signature }` when logging in via wallet
- update unit tests

## Testing
- `pnpm test` *(fails: DatabaseError, environment variables missing)*
- `npx tsc -p tsconfig.json --noEmit`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68596e33e22c8322b13770c48712cd1a