### PR TITLE
Refactor address validation

### DIFF
--- a/server/__tests__/address.test.ts
+++ b/server/__tests__/address.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { validateEthereumAddress } from '../utils/address';
+
+describe('validateEthereumAddress', () => {
+  it('accepts valid addresses', () => {
+    const res = validateEthereumAddress('0x742d35Cc6634C0532925a3b8D2B7D17a33b6C4d0');
+    expect(res.valid).toBe(true);
+    expect(res.address).toBe('0x742d35Cc6634C0532925a3b8D2B7D17a33b6C4d0');
+  });
+
+  it('rejects malformed addresses', () => {
+    const res = validateEthereumAddress('0x123');
+    expect(res.valid).toBe(false);
+  });
+
+  it('rejects bad checksum', () => {
+    const res = validateEthereumAddress('0x742d35cc6634c0532925a3b8d2b7d17a33b6c4d0');
+    expect(res.valid).toBe(false);
+  });
+});

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import bcrypt from 'bcryptjs';
 import crypto from 'crypto';
-import { ethers } from 'ethers';
+import { validateEthereumAddress } from './utils/address';
 import rateLimit, { MemoryStore } from 'express-rate-limit';
 import { loginSchema, registerSchema } from '../src/lib/validators';
 import { z } from 'zod';
@@ -15,21 +15,6 @@ export const authSecurityHeaders: express.RequestHandler = (_req, res, next) => 
   next();
 };
 
-export const validateEthereumAddress = (
-  address: unknown,
-): { valid: boolean; address?: string; error?: string } => {
-  if (!address || typeof address !== 'string') {
-    return { valid: false, error: 'Address must be a string' };
-  }
-  if (!/^0x[a-fA-F0-9]{40}$/.test(address)) {
-    return { valid: false, error: 'Invalid Ethereum address format' };
-  }
-  try {
-    return { valid: true, address: ethers.getAddress(address) };
-  } catch {
-    return { valid: false, error: 'Invalid address checksum' };
-  }
-};
 
 export const validateWalletAddress: express.RequestHandler = (req, res, next) => {
   const { walletAddress } = req.body as { walletAddress?: unknown };

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,7 +3,6 @@ import session from 'express-session';
 import cors from 'cors';
 import csurf from 'csurf';
 import { sanitize } from './utils/sanitize';
-import { ethers } from 'ethers';
 import { config } from './config';
 import { logSecurityEvent } from './logging';
 import { authRouter } from './auth';
@@ -12,6 +11,8 @@ import {
   resetDatabase,
   closePool,
 } from './db';
+
+export { validateEthereumAddress } from './utils/address';
 
 /**
  * Parse and validate cookie settings from environment variables.
@@ -54,27 +55,6 @@ const corsOptions = {
   allowedHeaders: ['Content-Type', 'Authorization'],
 };
 app.use(cors(corsOptions));
-
-
-interface AddressValidation {
-  valid: boolean;
-  address?: string;
-  error?: string;
-}
-
-export const validateEthereumAddress = (address: unknown): AddressValidation => {
-  if (!address || typeof address !== 'string') {
-    return { valid: false, error: 'Address must be a string' };
-  }
-  if (!/^0x[a-fA-F0-9]{40}$/.test(address)) {
-    return { valid: false, error: 'Invalid Ethereum address format' };
-  }
-  try {
-    return { valid: true, address: ethers.getAddress(address) };
-  } catch {
-    return { valid: false, error: 'Invalid address checksum' };
-  }
-};
 
 
 /**

--- a/server/utils/address.ts
+++ b/server/utils/address.ts
@@ -1,0 +1,24 @@
+import { ethers } from 'ethers';
+
+export interface AddressValidation {
+  valid: boolean;
+  address?: string;
+  error?: string;
+}
+
+/**
+ * Validate and normalize an Ethereum address.
+ */
+export function validateEthereumAddress(address: unknown): AddressValidation {
+  if (typeof address !== 'string') {
+    return { valid: false, error: 'Address must be a string' };
+  }
+  if (!/^0x[a-fA-F0-9]{40}$/.test(address)) {
+    return { valid: false, error: 'Invalid Ethereum address format' };
+  }
+  try {
+    return { valid: true, address: ethers.getAddress(address) };
+  } catch {
+    return { valid: false, error: 'Invalid address checksum' };
+  }
+}


### PR DESCRIPTION
## Summary
- centralize ethereum address validation in server/utils/address
- reuse address validation in auth.ts
- export validator from index.ts for tests
- add unit tests for address validator

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ERR_ERL_PERMISSIVE_TRUST_PROXY, Missing WebSocket base URL, database errors)*
- `pnpm type-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859739e52c4832294c25be56729addb