### PR TITLE
Implement strict input sanitization

### DIFF
--- a/src/lib/__tests__/security.test.ts
+++ b/src/lib/__tests__/security.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeInput } from '../security'
+
+// vitest runs in jsdom environment enabling DOMPurify
+
+describe('sanitizeInput', () => {
+  it('removes script tags and attributes', () => {
+    const dirty = '<img src=x onerror=alert(1)><script>alert(2)</script>'
+    const clean = sanitizeInput(dirty)
+    expect(clean).not.toMatch(/<script/)
+    expect(clean).not.toMatch(/onerror/)
+  })
+
+  it('trims whitespace and keeps text', () => {
+    const dirty = '  hello <b>world</b> '
+    const clean = sanitizeInput(dirty)
+    expect(clean).toBe('hello world')
+  })
+})

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -1,0 +1,12 @@
+import DOMPurify from 'dompurify'
+
+/**
+ * Sanitizes a user supplied string using DOMPurify in strict mode.
+ * All HTML tags and attributes are stripped from the input.
+ *
+ * @param input - The raw user input.
+ * @returns A sanitized string safe for further processing.
+ */
+export function sanitizeInput(input: string): string {
+  return DOMPurify.sanitize(input, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] }).trim()
+}

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,16 +1,7 @@
 import { z } from 'zod';
 import { getAddress } from 'ethers';
+import { sanitizeInput } from './security';
 
-const dangerousPatterns = [
-  /<script/i,
-  /javascript:/i,
-  /onload=/i,
-  /data:/i,
-];
-
-export const containsDangerousContent = (value: string): boolean => {
-  return dangerousPatterns.some(pattern => pattern.test(value));
-};
 
 export const isValidEthereumAddress = (address: string): boolean => {
   if (!address || typeof address !== 'string') return false;
@@ -29,49 +20,65 @@ const USERNAME_REGEX = /^[a-zA-Z0-9_-]{3,20}$/;
 export const loginSchema = z.object({
   email: z
     .string()
-    .email()
-    .refine(val => !containsDangerousContent(val), 'Invalid content'),
+    .transform(val => sanitizeInput(val))
+    .pipe(z.string().email()),
   password: z
     .string()
-    .min(8)
-    .regex(
-      PASSWORD_REGEX,
-      'Password must contain letters, numbers and symbols',
-    )
-    .refine(val => !containsDangerousContent(val), 'Invalid content'),
+    .transform(val => sanitizeInput(val))
+    .pipe(
+      z
+        .string()
+        .min(8)
+        .regex(
+          PASSWORD_REGEX,
+          'Password must contain letters, numbers and symbols',
+        ),
+    ),
 });
 
 export const registerSchema = z
   .object({
     username: z
       .string()
-      .min(3)
-      .max(20)
-      .regex(
-        USERNAME_REGEX,
-        'Username can only contain letters, numbers, underscores and hyphens',
-      )
-      .refine(val => !containsDangerousContent(val), 'Invalid content'),
+      .transform(val => sanitizeInput(val))
+      .pipe(
+        z
+          .string()
+          .min(3)
+          .max(20)
+          .regex(
+            USERNAME_REGEX,
+            'Username can only contain letters, numbers, underscores and hyphens',
+          ),
+      ),
     email: z
       .string()
-      .email()
-      .refine(val => !containsDangerousContent(val), 'Invalid content'),
+      .transform(val => sanitizeInput(val))
+      .pipe(z.string().email()),
     password: z
       .string()
-      .min(8)
-      .regex(
-        PASSWORD_REGEX,
-        'Password must contain letters, numbers and symbols',
-      )
-      .refine(val => !containsDangerousContent(val), 'Invalid content'),
+      .transform(val => sanitizeInput(val))
+      .pipe(
+        z
+          .string()
+          .min(8)
+          .regex(
+            PASSWORD_REGEX,
+            'Password must contain letters, numbers and symbols',
+          ),
+      ),
     confirmPassword: z
       .string()
-      .min(8)
-      .regex(
-        PASSWORD_REGEX,
-        'Password must contain letters, numbers and symbols',
-      )
-      .refine(val => !containsDangerousContent(val), 'Invalid content'),
+      .transform(val => sanitizeInput(val))
+      .pipe(
+        z
+          .string()
+          .min(8)
+          .regex(
+            PASSWORD_REGEX,
+            'Password must contain letters, numbers and symbols',
+          ),
+      ),
   })
   .refine(data => data.password === data.confirmPassword, {
     message: 'Passwords do not match',
@@ -80,6 +87,7 @@ export const registerSchema = z
 
 export const ethereumAddressSchema = z
   .string()
+  .transform(val => sanitizeInput(val))
   .regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address format')
   .refine(address => {
     try {
@@ -88,18 +96,17 @@ export const ethereumAddressSchema = z
     } catch {
       return false;
     }
-  }, 'Invalid address checksum')
-  .refine(val => !containsDangerousContent(val), 'Invalid content');
+  }, 'Invalid address checksum');
 
 export const walletLoginSchema = z.object({
   walletAddress: ethereumAddressSchema,
   signature: z
     .string()
-    .min(1)
-    .refine(val => !containsDangerousContent(val), 'Invalid content'),
+    .transform(val => sanitizeInput(val))
+    .pipe(z.string().min(1)),
   nonce: z
     .string()
-    .min(1)
-    .refine(val => !containsDangerousContent(val), 'Invalid content')
+    .transform(val => sanitizeInput(val))
+    .pipe(z.string().min(1))
     .optional(),
 });


### PR DESCRIPTION
## Summary
- add new `sanitizeInput` utility using DOMPurify
- sanitize all validators with the new function
- add tests for `sanitizeInput`

## Testing
- `pnpm test` *(fails: Missing WebSocket base URL, type errors)*
- `pnpm exec tsc --noEmit`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685994ddc23c8322aea002f27af3c01b