### PR TITLE
Add centralized validation schemas

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -3,7 +3,7 @@ import bcrypt from 'bcryptjs';
 import crypto from 'crypto';
 import { validateEthereumAddress } from './utils/address';
 import rateLimit, { MemoryStore } from 'express-rate-limit';
-import { loginSchema, registerSchema } from '../src/lib/validators';
+import { loginSchema, registerSchema } from '../src/lib/validation';
 import { z } from 'zod';
 import { verifyEip4361Signature, Web3AuthError } from './utils/web3Auth';
 import { logSecurityEvent } from './logging';

--- a/src/components/pages/ArticlePage.tsx
+++ b/src/components/pages/ArticlePage.tsx
@@ -34,6 +34,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import ArticleCard from '@/components/ui/ArticleCard';
 import { sanitizeHtml } from '@/lib/sanitizeHtml';
+import { commentSchema } from '@/lib/validation';
 
 interface Comment {
   id: string;
@@ -174,9 +175,10 @@ const ArticlePage: React.FC = () => {
       toast.error('Please sign in to comment');
       return;
     }
-    
-    if (!newComment.trim()) {
-      toast.error('Please enter a comment');
+
+    const parsed = commentSchema.safeParse({ content: newComment });
+    if (!parsed.success) {
+      toast.error(parsed.error.errors[0].message);
       return;
     }
 
@@ -191,7 +193,7 @@ const ArticlePage: React.FC = () => {
         name: user?.username || 'Anonymous',
         avatar: user?.avatar || '/images/avatars/default.jpg',
       },
-      content: newComment,
+      content: parsed.data.content,
       timestamp: new Date().toISOString(),
       likes: 0,
       dislikes: 0,

--- a/src/components/pages/AuthPage.tsx
+++ b/src/components/pages/AuthPage.tsx
@@ -9,7 +9,7 @@ import { Separator } from '@/components/ui/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
-import { loginSchema, registerSchema } from '@/lib/validators';
+import { loginSchema, registerSchema } from '@/lib/validation';
 import { logError } from '@/lib/errors';
 
 const AuthPage: React.FC = () => {

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -15,6 +15,7 @@ import {
 import { useData } from '@/contexts/DataContext';
 import ArticleCard from '@/components/ui/ArticleCard';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
+import { searchSchema } from '@/lib/validation';
 const TrendingSidebar = lazy(() => import('@/components/ui/TrendingSidebar'));
 
 const HomePage: React.FC = () => {
@@ -168,7 +169,10 @@ const HomePage: React.FC = () => {
                     type="search"
                     placeholder="Search articles..."
                     value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onChange={(e) => {
+                      const parsed = searchSchema.safeParse({ query: e.target.value });
+                      setSearchQuery(parsed.success ? parsed.data.query : e.target.value.slice(0, 100));
+                    }}
                     className="pl-10"
                   />
                 </div>

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -27,6 +27,7 @@ import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
 import { useData } from '@/contexts/DataContext';
 import ArticleCard from '@/components/ui/ArticleCard';
+import { profileUpdateSchema } from '@/lib/validation';
 
 interface SettingsForm {
   notifications: boolean;
@@ -101,15 +102,17 @@ const ProfilePage: React.FC = () => {
     user.bookmarks?.includes(article.id)
   );
 
-  const handleProfileSave = async () => {
-    setIsSaving(true);
-    
-    const success = await updateProfile({
-      username: profileForm.username,
-      email: profileForm.email,
-      bio: profileForm.bio,
-      avatar: profileForm.avatar,
-    });
+const handleProfileSave = async () => {
+  setIsSaving(true);
+
+  const parsed = profileUpdateSchema.safeParse(profileForm);
+  if (!parsed.success) {
+    toast.error(parsed.error.errors[0].message);
+    setIsSaving(false);
+    return;
+  }
+
+  const success = await updateProfile(parsed.data);
     
     if (success) {
       toast.success('Profile updated successfully');

--- a/src/lib/__tests__/validators.test.ts
+++ b/src/lib/__tests__/validators.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import {
-  loginSchema,
-  registerSchema,
   ethereumAddressSchema,
   walletLoginSchema,
 } from '../validators';
+import {
+  loginSchema,
+  registerSchema,
+  profileUpdateSchema,
+  commentSchema,
+  searchSchema,
+} from '../validation';
 
 describe('loginSchema', () => {
   it('validates correct data', () => {
@@ -136,3 +141,41 @@ describe('walletLoginSchema', () => {
     expect(result.success).toBe(false);
   });
 });
+
+describe('profileUpdateSchema', () => {
+  it('accepts partial profile data', () => {
+    const result = profileUpdateSchema.safeParse({ bio: 'Hello world' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid avatar url', () => {
+    const result = profileUpdateSchema.safeParse({ avatar: 'javascript:bad' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('commentSchema', () => {
+  it('rejects empty comment', () => {
+    const result = commentSchema.safeParse({ content: '' })
+    expect(result.success).toBe(false)
+  })
+
+  it('sanitizes script tags', () => {
+    const result = commentSchema.safeParse({ content: '<script>alert(1)</script>Test' })
+    expect(result.success).toBe(true)
+    expect(result.data.content).toBe('Test')
+  })
+})
+
+describe('searchSchema', () => {
+  it('trims long queries', () => {
+    const long = 'a'.repeat(150)
+    const result = searchSchema.safeParse({ query: long })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts normal query', () => {
+    const result = searchSchema.safeParse({ query: 'bitcoin' })
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod'
+import { sanitizeInput } from './security'
+
+const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/
+const USERNAME_REGEX = /^[a-zA-Z0-9_-]{3,20}$/
+
+export const loginSchema = z.object({
+  email: z
+    .string()
+    .transform(val => sanitizeInput(val))
+    .pipe(z.string().email()),
+  password: z
+    .string()
+    .transform(val => sanitizeInput(val))
+    .pipe(z.string().min(8).max(128).regex(PASSWORD_REGEX, 'Password must contain letters, numbers and symbols'))
+})
+
+export const registerSchema = z
+  .object({
+    username: z
+      .string()
+      .transform(val => sanitizeInput(val))
+      .pipe(z.string().min(3).max(20).regex(USERNAME_REGEX, 'Username can only contain letters, numbers, underscores and hyphens')),
+    email: z
+      .string()
+      .transform(val => sanitizeInput(val))
+      .pipe(z.string().email()),
+    password: z
+      .string()
+      .transform(val => sanitizeInput(val))
+      .pipe(z.string().min(8).max(128).regex(PASSWORD_REGEX, 'Password must contain letters, numbers and symbols')),
+    confirmPassword: z
+      .string()
+      .transform(val => sanitizeInput(val))
+      .pipe(z.string().min(8).max(128).regex(PASSWORD_REGEX, 'Password must contain letters, numbers and symbols'))
+  })
+  .refine(data => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword']
+  })
+
+export const profileUpdateSchema = z.object({
+  username: z
+    .string()
+    .transform(val => sanitizeInput(val))
+    .pipe(z.string().min(3).max(20).regex(USERNAME_REGEX, 'Invalid username'))
+    .optional(),
+  email: z
+    .string()
+    .transform(val => sanitizeInput(val))
+    .pipe(z.string().email())
+    .optional(),
+  bio: z
+    .string()
+    .transform(val => sanitizeInput(val))
+    .pipe(z.string().max(300))
+    .optional(),
+  avatar: z
+    .string()
+    .transform(val => sanitizeInput(val))
+    .pipe(z.string().url())
+    .optional(),
+  displayName: z
+    .string()
+    .transform(val => sanitizeInput(val))
+    .pipe(z.string().max(50))
+    .optional()
+})
+
+export const commentSchema = z.object({
+  content: z
+    .string()
+    .transform(val => sanitizeInput(val))
+    .pipe(z.string().min(1).max(1000))
+})
+
+export const searchSchema = z.object({
+  query: z
+    .string()
+    .transform(val => sanitizeInput(val))
+    .pipe(z.string().max(100))
+})

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { getAddress } from 'ethers';
 import { sanitizeInput } from './security';
+import { loginSchema, registerSchema } from './validation';
 
 
 export const isValidEthereumAddress = (address: string): boolean => {
@@ -14,76 +15,7 @@ export const isValidEthereumAddress = (address: string): boolean => {
   }
 };
 
-const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
-const USERNAME_REGEX = /^[a-zA-Z0-9_-]{3,20}$/;
 
-export const loginSchema = z.object({
-  email: z
-    .string()
-    .transform(val => sanitizeInput(val))
-    .pipe(z.string().email()),
-  password: z
-    .string()
-    .transform(val => sanitizeInput(val))
-    .pipe(
-      z
-        .string()
-        .min(8)
-        .regex(
-          PASSWORD_REGEX,
-          'Password must contain letters, numbers and symbols',
-        ),
-    ),
-});
-
-export const registerSchema = z
-  .object({
-    username: z
-      .string()
-      .transform(val => sanitizeInput(val))
-      .pipe(
-        z
-          .string()
-          .min(3)
-          .max(20)
-          .regex(
-            USERNAME_REGEX,
-            'Username can only contain letters, numbers, underscores and hyphens',
-          ),
-      ),
-    email: z
-      .string()
-      .transform(val => sanitizeInput(val))
-      .pipe(z.string().email()),
-    password: z
-      .string()
-      .transform(val => sanitizeInput(val))
-      .pipe(
-        z
-          .string()
-          .min(8)
-          .regex(
-            PASSWORD_REGEX,
-            'Password must contain letters, numbers and symbols',
-          ),
-      ),
-    confirmPassword: z
-      .string()
-      .transform(val => sanitizeInput(val))
-      .pipe(
-        z
-          .string()
-          .min(8)
-          .regex(
-            PASSWORD_REGEX,
-            'Password must contain letters, numbers and symbols',
-          ),
-      ),
-  })
-  .refine(data => data.password === data.confirmPassword, {
-    message: 'Passwords do not match',
-    path: ['confirmPassword'],
-  });
 
 export const ethereumAddressSchema = z
   .string()


### PR DESCRIPTION
## Summary
- centralize zod validation in `src/lib/validation.ts`
- update backend to use the new schemas
- validate profile updates, comments and search queries in frontend
- adjust tests to cover new schemas

## Testing
- `pnpm lint`
- `npx tsc -p tsconfig.json --noEmit`
- `pnpm test` *(fails: ERR_ERL_PERMISSIVE_TRUST_PROXY and other environment errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859a6ba84148322b5a0b883d565a4bb