### PR TITLE
Implement validation type exports

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -80,3 +80,9 @@ export const searchSchema = z.object({
     .transform(val => sanitizeInput(val))
     .pipe(z.string().max(100))
 })
+
+export type LoginCredentials = z.infer<typeof loginSchema>
+export type RegisterCredentials = z.infer<typeof registerSchema>
+export type ProfileUpdate = z.infer<typeof profileUpdateSchema>
+export type CommentInput = z.infer<typeof commentSchema>
+export type SearchQuery = z.infer<typeof searchSchema>


### PR DESCRIPTION
## Summary
- export types for validation schemas

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Missing WebSocket base URL, DB issues)*
- `pnpm test:security` *(fails: Missing WebSocket base URL, DB issues)*
- `npx tsc --noEmit`
- `pnpm audit --audit-level moderate`


------
https://chatgpt.com/codex/tasks/task_e_6859e98c670c8322983bbfda7b724e42