### PR TITLE
Apply nonce headers in dev server

### DIFF
--- a/server/__tests__/vitePlugin.test.ts
+++ b/server/__tests__/vitePlugin.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest'
+import { securityPlugin } from '../../vite.config'
+
+describe('securityPlugin', () => {
+  it('adds CSP nonce via middleware', () => {
+    let captured: any
+    const server = {
+      middlewares: {
+        use(fn: any) {
+          captured = fn
+        },
+      },
+    } as any
+
+    securityPlugin().configureServer!(server)
+
+    const res: any = { setHeader: vi.fn(), locals: {} }
+    const next = vi.fn()
+    captured({}, res, next)
+
+    const call = res.setHeader.mock.calls.find((c: any[]) => c[0] === 'Content-Security-Policy')
+    expect(call?.[1]).toMatch(/nonce-[^';]+/)
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,29 @@
-import path from "path"
-import react from "@vitejs/plugin-react"
-import { defineConfig } from "vite"
+import path from 'path'
+import react from '@vitejs/plugin-react'
+import { defineConfig, type Plugin } from 'vite'
+import type { Request, Response, NextFunction } from 'express'
+import { securityMiddleware } from './server/middleware/security'
+
+export function securityPlugin(): Plugin {
+  return {
+    name: 'security-middleware',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        securityMiddleware(
+          req as unknown as Request,
+          res as unknown as Response,
+          next as NextFunction,
+        )
+      })
+    },
+  }
+}
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), securityPlugin()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': path.resolve(__dirname, './src'),
     },
   },
 })


### PR DESCRIPTION
## Summary
- add security middleware plugin for Vite dev server
- test CSP nonce injection in Vite plugin

## Testing
- `pnpm test` *(fails: DatabaseError, Missing WebSocket base URL)*
- `pnpm test:security` *(fails: environment validation, rate limit error)*
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm audit --audit-level moderate`


------
https://chatgpt.com/codex/tasks/task_e_6859ec6090c88322ac6b885a99c5fd79